### PR TITLE
Assigns missing originating organisation for PAs

### DIFF
--- a/db/migrate/20160709082305_assign_missing_originating_organisation.rb
+++ b/db/migrate/20160709082305_assign_missing_originating_organisation.rb
@@ -1,0 +1,9 @@
+class AssignMissingOriginatingOrganisation < ActiveRecord::Migration
+  def up
+    execute "UPDATE plant_accessions SET originating_organisation = 'RRES' WHERE originating_organisation IS NULL"
+  end
+
+  def down
+    execute "UPDATE plant_accessions SET originating_organisation = NULL WHERE originating_organisation = 'RRES'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160624115946) do
+ActiveRecord::Schema.define(version: 20160709082305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Fixes #568 

Fixes #560 

In consequence, also kind of fixes #560 - there are no longer null-oo PAs in the DB and there should be none in the future, since we now require that column.

I stick with just the mnemonic RRES since this is how they call Rothamsted in other parts of CS data.