### PR TITLE
Do not remove nonexistent record from ES index on update

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -14,7 +14,7 @@ module Searchable extend ActiveSupport::Concern
     end
 
     after_commit(on: :update) do
-      if !published?
+      if !published? && __elasticsearch__.client.exists(id: id, index: self.class.index_name)
         __elasticsearch__.delete_document
       elsif __elasticsearch__.client.exists(id: id, index: self.class.index_name)
         __elasticsearch__.update_document


### PR DESCRIPTION
@kammerer Can you add in `searchable_spec.rb` line 98 some code to check if the index was updated (this is besides the error, just added another example to test another case which, I think, was untested)?