### PR TITLE
Privacy aware reindexing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 rvm:
   - 2.2.1
 
+cache: bundler
+
 addons:
   postgresql: "9.3"
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 ## Brassica Information Portal
 
-The Brassica Information Portal (BIP) is a web repository for population and trait scoring information related to the Brassica breeding community. Advanced data submission capabilities and APIs enable users to store and publish their own study results in our Portal. 
+The Brassica Information Portal (BIP) is a web repository for population and trait scoring information related to the Brassica breeding community. Advanced data submission capabilities and APIs enable users to store and publish their own study results in our Portal.
 Release embargos can be placed on datasets to reflect the need for scientists to publish their data in time with associated publications. The repository can be easily browsed thanks to a set of user-friendly query interfaces. Data download can be achieved using the API to feed into downstream analysis tools or via the web-interface.
 
-The portal caters for the growing interest in phenotype data storage, reproducibility, and user controlled data sharing and analysis in integrated genotype-phenotype association studies aimed for crop improvement. 
+The portal caters for the growing interest in phenotype data storage, reproducibility, and user controlled data sharing and analysis in integrated genotype-phenotype association studies aimed for crop improvement.
 The use of ontologies and nomenclature will make it easier to make conclusions on genotype-phenotype relationships within and across Brassica species. We currently use [Plant and Trait Ontology] (https://archive.gramene.org/plant_ontology/ontology_browse.html#tax) as reference ontologies for plants. And [GR_tax ontology ](https://archive.gramene.org/plant_ontology/ontology_browse.html#tax)to cover Brassica taxonomy.
 Marker sequences are currently cross-referenced with resources such as [Genebank(NCBI)](https://www.ncbi.nlm.nih.gov/genbank/) and [EnsemblPlants](https://plants.ensembl.org/index.html) where possible, which will be expanded in the future.
 
 It is a Rails web application and was created by eSpectrum company on a contract with the Earlham Institute (former The Genome Analysis Centre) but it is released as a free and open source project (see the LICENSE.txt file). The underlying database schema is derived from the CropStoreDB schema ver.7, with the original version developed by <a href="mailto:Graham.King@scu.edu.au">Graham King</a> and Pierre Carion at [Rothamsted Research](https://www.rothamsted.ac.uk/).
 
-Apart from the LICENSE, TGAC explicitly requests any party that wishes to deploy a copy (modified or not) of BIP on their own servers, to contact, and obtain permission to do so. For that, please contact 
+Apart from the LICENSE, TGAC explicitly requests any party that wishes to deploy a copy (modified or not) of BIP on their own servers, to contact, and obtain permission to do so. For that, please contact
 <a href="mailto:bip@earlham.ac.uk">bip@earlham.ac.uk</a>. If you are interested in contributing to the project, for example by adding any analytics tools, please contact us, too.
 For further contact information on people behind the project or the database itself, please see the [about us](https://bip.earlham.ac.uk/about) section.
 
@@ -75,6 +75,15 @@ you need to:
 To perform deploy run:
 
     bin/cap production deploy
+
+If any changes were introduced to ES index definitions or data migrations
+affecting indices were performed it is necessary to reindex data:
+
+  bin/cap production search:reindex:all
+
+Or:
+
+  bin/cap production search:reindex:model CLASS=<class name>
 
 
 ## Testing

--- a/app/services/search/index_builder.rb
+++ b/app/services/search/index_builder.rb
@@ -1,0 +1,10 @@
+class Search::IndexBuilder
+  def call(klass)
+    klass.__elasticsearch__.delete_index!
+    klass.__elasticsearch__.create_index!
+
+    klass.published.find_each { |record| record.__elasticsearch__.index_document }
+
+    klass.__elasticsearch__.refresh_index!
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,29 +34,3 @@ set :default_env, {
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
-
-namespace :deploy do
-  after :finished, :rebuild_indices do
-    on roles(:app), in: :groups, limit: 1, wait: 10 do
-      within release_path do
-        execute :rake, "environment elasticsearch:import:model CLASS='PlantLine' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='PlantPopulation' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='PlantVariety' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='LinkageGroup' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='LinkageMap' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='MapPosition' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='MapLocusHit' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='PopulationLocus' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='MarkerAssay' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='Primer' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='Probe' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='PlantTrial' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='Qtl' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='TraitDescriptor' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='PlantScoringUnit' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='PlantAccession' FORCE=y"
-        execute :rake, "environment elasticsearch:import:model CLASS='QtlJob' FORCE=y"
-      end
-    end
-  end
-end

--- a/lib/capistrano/tasks/search.rake
+++ b/lib/capistrano/tasks/search.rake
@@ -1,0 +1,21 @@
+namespace :search do
+  namespace :reindex do
+    desc "Destroy, recreate and populate ES indices with public records"
+    task :all do
+      on roles(:app), in: :groups, limit: 1, wait: 10 do
+        within release_path do
+          klasses = %w(
+            PlantLine PlantPopulation PlantVariety LinkageGroup LinkageMap
+            MapPosition MapLocusHit PopulationLocus MarkerAssay Primer
+            Probe PlantTrial Qtl TraitDescriptor PlantScoringUnit
+            PlantAccession QtlJob
+          )
+
+          klasses.each do |klass|
+            execute :rake, "search:reindex:model CLASS='#{klass}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -7,5 +7,12 @@ namespace :search do
 
       Search::IndexBuilder.new.call(klass)
     end
+
+    desc "Destroy, recreate and populate all ES indices with public records"
+    task all: :environment do
+      Searchable.classes do |klass|
+        Search::IndexBuilder.new.call(klass)
+      end
+    end
   end
 end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,0 +1,11 @@
+namespace :search do
+  namespace :reindex do
+    desc "Destroy, recreate and populate index with public records"
+    task model: :environment do
+      klass_name = ENV.fetch("CLASS") { puts "Missing CLASS=<class name>"; exit }
+      klass = klass_name.classify.constantize
+
+      Search::IndexBuilder.new.call(klass)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.include RSpecHtmlMatchers
   include CommonHelpers
+  config.include ElasticsearchHelper, :elasticsearch
 
   config.before :suite do
     DatabaseCleaner.clean_with :truncation

--- a/spec/services/search/index_builder_spec.rb
+++ b/spec/services/search/index_builder_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Search::IndexBuilder, :elasticsearch do
+  context "with already indexed records" do
+    before(:all) do
+      create(:plant_trial, plant_trial_name: "Foobar", published: true)
+
+      refresh_index(PlantTrial)
+
+      # Using #delete_all, not #destroy_all, so that index is not touched
+      PlantTrial.delete_all
+    end
+
+    it "clears already indexed records" do
+      expect { subject.call(PlantTrial) }.to \
+        change { PlantTrial.search("Foobar").count }.
+        from(1).to(0)
+    end
+  end
+
+  context "with published records" do
+    before(:all) do
+      create(:plant_trial, plant_trial_name: "Foobar", published: true)
+
+      delete_index(PlantTrial)
+      create_index(PlantTrial)
+      refresh_index(PlantTrial)
+    end
+
+    it "indexes published records" do
+      expect { subject.call(PlantTrial) }.to \
+        change { PlantTrial.search("Foobar").count }.
+        from(0).to(1)
+    end
+  end
+
+  context "with private records" do
+    before(:all) do
+      create(:plant_trial, plant_trial_name: "Foobar", published: false, published_on: nil)
+
+      delete_index(PlantTrial)
+      create_index(PlantTrial)
+      refresh_index(PlantTrial)
+    end
+
+    it "does not index private records" do
+      expect { subject.call(PlantTrial) }.not_to \
+        change { PlantTrial.search("Foobar").count }
+
+      expect(PlantTrial.search("Foobar").count).to eq(0)
+    end
+  end
+end

--- a/spec/services/search_spec.rb
+++ b/spec/services/search_spec.rb
@@ -138,8 +138,7 @@ RSpec.describe Search, :elasticsearch, :dont_clean_db do
     # Special cases
     create(:plant_line, plant_line_name: "12345@67890")
 
-    # FIXME without sleep ES is not able to update index in time
-    sleep 1
+    refresh_index(*Searchable.classes)
   end
 
   after(:all) do

--- a/spec/support/elasticsearch_helper.rb
+++ b/spec/support/elasticsearch_helper.rb
@@ -1,0 +1,19 @@
+module ElasticsearchHelper
+  def create_index(*klasses)
+    klasses.each { |klass| klass.__elasticsearch__.create_index! }
+  end
+
+  def delete_index(*klasses)
+    klasses.each { |klass| klass.__elasticsearch__.delete_index! }
+  end
+
+  def refresh_index(*klasses)
+    klasses.each { |klass| klass.__elasticsearch__.refresh_index! }
+    wait_for_indexes
+  end
+
+  def wait_for_indexes
+    client = Elasticsearch::Client.new
+    client.cluster.health(wait_for_status: :yellow)
+  end
+end


### PR DESCRIPTION
Fixes #615 and #616 

After all, no special flag is needed for #615. Instead we will call `bin/cap production search:reindex:all` after performing deployment if rebuilding indices is needed.