### PR TITLE
Zenodo deposition tweaks

### DIFF
--- a/app/decorators/submission_decorator.rb
+++ b/app/decorators/submission_decorator.rb
@@ -10,7 +10,7 @@ class SubmissionDecorator < Draper::Decorator
   end
 
   def further_details
-    raise Exception.new('Should be extended by subclasses')
+    raise NotImplementedError, "Must be implemented by subclasses"
   end
 
   def details_path
@@ -31,6 +31,6 @@ class SubmissionDecorator < Draper::Decorator
   end
 
   def label
-    raise Exception.new('Should be extended by subclasses')
+    raise NotImplementedError, "Must be implemented by subclasses"
   end
 end

--- a/app/services/zenodo_depositor.rb
+++ b/app/services/zenodo_depositor.rb
@@ -103,8 +103,8 @@ class ZenodoDepositor
   end
 
   def contributors
-    names = @deposition.contributors.split("\n")
-    names.select(&:present?).map { |contributor|
+    names = @deposition.contributors.lines.map(&:strip).select(&:present?)
+    names.map { |contributor|
       { name: contributor, type: 'Researcher' }
     }
   end

--- a/app/services/zenodo_depositor.rb
+++ b/app/services/zenodo_depositor.rb
@@ -12,18 +12,51 @@ class ZenodoDepositor
   # 3. Publishes that deposition (i.e. makes it available to public)
   # 4. Saves assigned DOI in submission
   def call
-    unless @deposition && @deposition.valid?
-      report_problem 'Got nil or invalid Deposition. Unable to upload it to Zenodo.'
-      return
+    unless @deposition.try(:valid?)
+      raise ArgumentError, 'Got nil or invalid Deposition. Unable to upload it to Zenodo.'
     end
 
-    documents_to_deposit = @deposition.documents_to_deposit
-    if documents_to_deposit.empty?
-      report_problem 'Nothing to deposit in Zenodo - deposition documents empty.'
-      return
-    end
+    return unless check_documents_presence
 
-    request = Typhoeus::Request.new(
+    deposition_request.tap do |request|
+      submit_request(request) do |response|
+        remote_deposition = JSON.parse(response.body)
+
+        deposited_file_count = 0
+        # We need a temp dir for deposition files
+        Dir.mktmpdir do |files_directory|
+          documents_to_deposit.each do |name, contents|
+            file = write_file(contents, files_directory, "#{name}.csv")
+            deposition_file_request(remote_deposition, file).tap do |file_request|
+              submit_request(file_request) { deposited_file_count += 1 }
+            end
+          end
+        end
+
+        if deposited_file_count == documents_to_deposit.size
+          # All documents were successfully deposited, time to Publish
+          deposition_publish_request(remote_deposition).tap do |publish_request|
+            submit_request(publish_request) do |publish_response|
+              remote_deposition = JSON.parse(publish_response.body)
+              set_submission_doi(remote_deposition)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def check_documents_presence
+    return true if documents_to_deposit.present?
+
+    report_problem 'Nothing to deposit in Zenodo - deposition documents empty.'
+    false
+  end
+
+  def deposition_request
+    Typhoeus::Request.new(
       query_url,
       method: :post,
       headers: { 'Content-Type' => 'application/json' },
@@ -32,7 +65,7 @@ class ZenodoDepositor
           upload_type: 'dataset',
           title: @deposition.title,
           creators: @deposition.creators,
-          contributors: contributors_json,
+          contributors: contributors,
           description: @deposition.description,
           keywords: ['Brassica', 'Phenotyping', 'Association studies'],
           subjects: [
@@ -44,63 +77,50 @@ class ZenodoDepositor
         }
       }.to_json
     )
-
-    submit_request(request) do |response|
-      remote_deposition = JSON.parse(response.body)
-
-      deposited_file_count = 0
-      # We need a temp dir for deposition files
-      Dir.mktmpdir do |files_directory|
-        documents_to_deposit.each do |name, contents|
-          next if contents.empty?
-          request = Typhoeus::Request.new(
-            query_url("/#{remote_deposition['id']}/files"),
-            method: :post,
-            headers: { 'Content-Type' => 'multipart/form-data' },
-            body: {
-              filename: "#{name}.csv",
-              file: write_file(contents, files_directory, "#{name}.csv")
-            }
-          )
-          submit_request(request) do |_|
-            # Success
-            deposited_file_count += 1
-          end
-        end
-      end
-
-      if deposited_file_count == documents_to_deposit.size
-        # All documents were successfully deposited, time to Publish
-        request = Typhoeus::Request.new(
-          query_url("/#{remote_deposition['id']}/actions/publish"),
-          method: :post
-        )
-        submit_request(request) do |publish_response|
-          remote_deposition = JSON.parse(publish_response.body)
-          if @deposition.submission
-            @deposition.submission.doi = remote_deposition['doi']
-            @deposition.submission.save!
-          end
-        end
-      end
-    end
   end
 
-  private
+  def deposition_file_request(remote_deposition, file)
+    Typhoeus::Request.new(
+      query_url("/#{remote_deposition['id']}/files"),
+      method: :post,
+      headers: { 'Content-Type' => 'multipart/form-data' },
+      body: {
+        filename: Pathname(file.path).basename.to_s,
+        file: file
+      }
+    )
+  end
 
-  def contributors_json
+  def deposition_publish_request(remote_deposition)
+    Typhoeus::Request.new(
+      query_url("/#{remote_deposition['id']}/actions/publish"),
+      method: :post
+    )
+  end
+
+  def documents_to_deposit
+    @deposition.documents_to_deposit.select { |_, contents| contents.present? }
+  end
+
+  def contributors
     names = @deposition.contributors.split("\n")
-    names = names.select(&:present?)
-    names.map { |contributor|
+    names.select(&:present?).map { |contributor|
       { name: contributor, type: 'Researcher' }
     }
   end
 
   def write_file(contents, files_directory, filename)
-    file = File.open("#{files_directory}/#{filename}", 'w')
-    file.write contents
-    file.rewind
-    file
+    path = File.join(files_directory, filename)
+    File.open(path, 'w').tap do |file|
+      file.write(contents)
+      file.rewind
+    end
+  end
+
+  def set_submission_doi(remote_deposition)
+    return unless @deposition.submission
+    @deposition.submission.doi = remote_deposition['doi']
+    @deposition.submission.save!
   end
 
   def submit_request(request)

--- a/app/views/submissions/_publishing.html.haml
+++ b/app/views/submissions/_publishing.html.haml
@@ -22,7 +22,8 @@
                        title: tooltip)
 
 - elsif submission.depositable?
-  = link_to "Request a DOI",
-            new_deposition_path(deposition: { submission_id: submission.id }),
-            class: "btn #{btn_size} btn-primary pull-right",
-            title: 'Deposit this submission content in Zenodo.org to get official dataset DOI number.'
+  .actions
+    = link_to "Request a DOI",
+              new_deposition_path(deposition: { submission_id: submission.id }),
+              class: "btn #{btn_size} btn-primary pull-right",
+              title: 'Deposit this submission content in Zenodo.org to get official dataset DOI number.'

--- a/spec/decorators/submission_decorator_spec.rb
+++ b/spec/decorators/submission_decorator_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe SubmissionDecorator do
       submission = create(:submission)
       sd = SubmissionDecorator.decorate(submission)
       expect { sd.further_details }.
-        to raise_error('Should be extended by subclasses')
+        to raise_error('Must be implemented by subclasses')
       expect { sd.label }.
-        to raise_error('Should be extended by subclasses')
+        to raise_error('Must be implemented by subclasses')
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -107,7 +107,6 @@ VCR.configure do |c|
   c.hook_into :typhoeus
   c.hook_into :webmock
   c.default_cassette_options = { record: :new_episodes, re_record_interval: 7.days }
-  # FIXME: put ES server into configuration
-  c.ignore_hosts '127.0.0.1', 'localhost'  # ES server
+  c.ignore_hosts URI.parse(Rails.application.config_for(:elasticsearch).fetch("host")).host
   c.ignore_hosts 'pub.orcid.org', 'sandbox.orcid.org'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -107,6 +107,7 @@ VCR.configure do |c|
   c.hook_into :typhoeus
   c.hook_into :webmock
   c.default_cassette_options = { record: :new_episodes, re_record_interval: 7.days }
+  # FIXME: put ES server into configuration
   c.ignore_hosts '127.0.0.1', 'localhost'  # ES server
   c.ignore_hosts 'pub.orcid.org', 'sandbox.orcid.org'
 end

--- a/spec/services/zenodo_depositor_spec.rb
+++ b/spec/services/zenodo_depositor_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe ZenodoDepositor do
   let(:population_deposition) { Deposition.new(submission: population_submission) }
   let(:private_deposition) { Deposition.new(submission: private_submission) }
 
-  it 'does nothing for broken deposition' do
+  it 'fails with error for broken deposition' do
     expect_any_instance_of(Typhoeus::Request).not_to receive(:run)
-    deposit(nil)
-    deposit(Deposition.new)
-    deposit(Deposition.new(title: 't'))
+    error_msg = "Got nil or invalid Deposition. Unable to upload it to Zenodo."
+    expect { deposit(nil) }.to raise_error(ArgumentError, error_msg)
+    expect { deposit(Deposition.new) }.to raise_error(ArgumentError, error_msg)
+    expect { deposit(Deposition.new(title: 't')) }.to raise_error(ArgumentError, error_msg)
   end
 
   it 'handles network errors gracefully' do

--- a/spec/services/zenodo_depositor_spec.rb
+++ b/spec/services/zenodo_depositor_spec.rb
@@ -3,8 +3,12 @@ require 'rails_helper'
 RSpec.describe ZenodoDepositor do
   let(:population_submission) { create(:submission, :population, :finalized, published: true) }
   let(:private_submission) { create(:submission, :population, :finalized, published: false) }
-  let(:population_deposition) { Deposition.new(submission: population_submission) }
+  let(:population_deposition) {
+    Deposition.new(submission: population_submission, contributors: contributors)
+  }
   let(:private_deposition) { Deposition.new(submission: private_submission) }
+  let(:contributors) { "Foo Bar\r\nBaz B. Lah" }
+
 
   it 'fails with error for broken deposition' do
     expect_any_instance_of(Typhoeus::Request).not_to receive(:run)


### PR DESCRIPTION
- Fixes #630 
- Simple refactoring of `ZenodoDepositor`
- Fail with error in case of broken deposition instead of showing a message to the user*
- A bunch of minor tweaks

[*] Actually, it may be OK to show the message, but we also should be notified