### PR TITLE
Touch cascade optimization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
+gem 'activerecord-delay_touching'
+
 gem 'pg'
 
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       activemodel (= 4.2.6)
       activesupport (= 4.2.6)
       arel (~> 6.0)
+    activerecord-delay_touching (1.0.1)
+      activerecord (>= 4.2)
     activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -374,6 +376,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-delay_touching
   annotate
   autoprefixer-rails (~> 5.1.5)
   better_errors

--- a/app/models/plant_trial.rb
+++ b/app/models/plant_trial.rb
@@ -4,6 +4,9 @@ class PlantTrial < ActiveRecord::Base
   belongs_to :user
 
   after_update { plant_scoring_units.each(&:touch) }
+  around_destroy do |_, block|
+    ActiveRecord::Base.delay_touching { block.call }
+  end
 
   has_many :plant_scoring_units, dependent: :destroy
   has_many :processed_trait_datasets

--- a/app/services/submission/plant_trial_finalizer.rb
+++ b/app/services/submission/plant_trial_finalizer.rb
@@ -10,10 +10,12 @@ class Submission::PlantTrialFinalizer
 
   def call
     ActiveRecord::Base.transaction do
-      create_plant_trial
-      create_new_trait_descriptors
-      create_scoring
-      update_submission
+      ActiveRecord::Base.delay_touching do
+        create_plant_trial
+        create_new_trait_descriptors
+        create_scoring
+        update_submission
+      end
     end
     submission.finalized?
   end


### PR DESCRIPTION
Fixes #625 

Due to my benchmarks (ES-enabled, development env.), for finalizing "published" PT which created 50 PSUs and 200 TSes, this reduced the operation time from ~33 seconds to ~7.5 seconds. Finalized submission `publish` and `revoke` actions should have even greater speedup (up to 8x faster). Also destroying complex PTs were very slow and this speeds that up considerably.

The problem was that a lot of records were `touched` multiple times, while only a single touch was needed. This is a recognized flaw in AR (https://github.com/rails/rails/issues/18606) which was eventually removed in Rails 5.