### PR TITLE
Mass-inserts TSes during PT submission finalization

### DIFF
--- a/app/services/submission/plant_trial_finalizer.rb
+++ b/app/services/submission/plant_trial_finalizer.rb
@@ -135,7 +135,7 @@ class Submission::PlantTrialFinalizer
 
           # Ensure consistent order of raw values (by column name)
           trait_score_attributes.sort.map do |_,v|
-            TraitScore.send(:sanitize, v)
+            TraitScore.sanitize(v)
           end
       end
 

--- a/spec/services/submission/plant_trial_finalizer_spec.rb
+++ b/spec/services/submission/plant_trial_finalizer_spec.rb
@@ -170,6 +170,15 @@ RSpec.describe Submission::PlantTrialFinalizer do
       expect(TraitScore.find_by(score_value: 'z').plant_scoring_unit.scoring_unit_name).to eq 'p3'
     end
 
+    it 'updates counter caches for trait scores accordingly' do
+      expect{ subject.call }.to change{ TraitScore.count }.by(3)
+
+      expect(PlantScoringUnit.pluck(:scoring_unit_name, :trait_scores_count)).
+        to match_array [['p1', 0], ['p2', 1], ['p3', 2], ['p4', 0]]
+      expect(TraitDescriptor.pluck(:trait_scores_count)).
+        to match_array [1, 1, 1]
+    end
+
     context 'when dealing with plant lines and plant varieties' do
       it 'creates or assigns plant varieties for new accessions only' do
         submission.content.update(:step04,


### PR DESCRIPTION
Another optimization in PT submission. This time we bulk-insert TS data for each PSU, and we update TD.tsc and PSU.tsc counters only once.

For 380 PSU and 22 TS per PSU (+8k TSes in total) - our current benchmark - it reduces published submission finalization >7 times (from over 7 min to 53 secs).

Fixes #625