### PR TITLE
Assumes query param may not be a hash

### DIFF
--- a/app/views/data_tables/index.html.haml
+++ b/app/views/data_tables/index.html.haml
@@ -12,7 +12,10 @@
         %span.label.label-info
           = surround '[',']' do
             - if params[:query].present?
-              = params[:query].map{ |k,v| "#{k} = #{v}" }.join(' && ')
+              - if params[:query].is_a?(Hash)
+                = params[:query].map{ |k,v| "#{k} = #{v}" }.join(' && ')
+              - else
+                = params[:query]
             - if params[:fetch].present?
               = "search = "
               = params[:fetch]


### PR DESCRIPTION
Fixes today's (1.09.16) production issue. Caused by a user playing with possible query settings.