### PR TITLE
Fist implementation of germplasm-search BrAPIv1 call

### DIFF
--- a/app/controllers/brapi/base_controller.rb
+++ b/app/controllers/brapi/base_controller.rb
@@ -1,0 +1,20 @@
+class Brapi::BaseController < ActionController::Metal
+  include AbstractController::Rendering
+  include ActionController::Helpers
+  include ActionController::Redirecting
+  include ActionController::Rendering
+  include ActionController::Renderers
+  include ActionController::Renderers::All
+  include ActionController::ConditionalGet
+  include ActionController::EtagWithTemplateDigest
+  include ActionController::MimeResponds
+  include ActionController::Caching
+  include ActionController::ForceSSL
+  include AbstractController::Callbacks
+  include ActionController::Instrumentation
+  include ActionController::ParamsWrapper
+  include ActionController::StrongParameters
+  include ActionController::Rescue
+
+  include Rails.application.routes.url_helpers
+end

--- a/app/controllers/brapi/v1/germplasm_controller.rb
+++ b/app/controllers/brapi/v1/germplasm_controller.rb
@@ -1,0 +1,250 @@
+class Brapi::V1::GermplasmController < Brapi::BaseController
+
+  attr_accessor :request_params, :user
+
+  before_filter :authenticate_api_key!
+
+
+  rescue_from 'ActiveRecord::InvalidForeignKey' do |exception|
+    message = exception.message.split("\n").try(:second)
+    attribute = message ? message[14..-1].split(')')[0] : ''
+    render json: { errors: { attribute: attribute, message: message } }, status: 422
+  end
+
+  rescue_from ActionController::ParameterMissing do |exception|
+    render json: { errors: { attribute: exception.param, message: exception.message } }, status: 422
+  end
+
+
+
+
+ def search
+    # accepted params: germplasmPUI , germplasmDbId , germplasmName , pageSize , page
+    # domainParameters = ['germplasmPUI','germplasmDbId','germplasmName']
+    # totalParameters = domainParameters + ['pageSize','page']
+    
+    if !params['germplasmPUI'].present? && !params['germplasmDbId'].present? && !params['germplasmName'].present?
+      render json: { reason: 'Resource not found' }, status: :not_found
+    else 
+      result_object = germplasm_query(params, false)
+      records = result_object.values
+      
+      
+      if records.nil?
+        render json: { reason: 'Resource not found' }, status: :not_found
+      else
+        if records.size == 1 && records[0]!=nil && records[0] != api_key.user_id && records[1] 
+          render json: { reason: 'This is a private resource of another user' }, status: :unauthorized
+        else
+          json_result_array = []
+          
+          # any programmatic data manipulation can be done here
+          result_object.each do |row|
+            row = JSON.parse(row["row_to_json"])
+            puts row
+            if (!row[:user_id] || (row[:user_id]!=nil && row[:user_id] != api_key.user_id && row[:published] ))
+              json_result_array << row
+            end
+          end
+          
+          # pagination data returned
+          page = get_page
+          pageSize = get_pageSize 
+          
+          result_count_object = germplasm_query(params, true)
+          totalCount = result_count_object.values.first[0].to_i
+          totalPages = (totalCount/pageSize.to_f).ceil
+          
+          json_response = { 
+            'metadata' => json_metadata(pageSize, page, totalCount, totalPages),
+            'result' => json_result_array
+          }
+         
+          render json: json_response, :except => ["id", "user_id", "created_at", "updated_at","total_entries_count"]
+        end
+      end
+      
+    
+    end
+  end
+
+
+
+
+  private
+
+
+
+  # processing result: https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/GermplasmSearchGET.md 
+  # All possible fields to return:
+  # germplasmDbId, defaultDisplayName, accessionNumber, germplasmName, germplasmPUI, pedigree, 
+  # seedSource, synonyms, commonCropName, instituteCode, instituteName, biologicalStatusOfAccessionCode, 
+  # countryOfOriginCode, typeOfGermplasmStorageCode, genus, species, speciesAuthority, subtaxa, subtaxaAuthority, 
+  # donors, acquisitionDate
+
+  def germplasm_query(params, count_mode)
+    # where conditions
+    where_query = " "
+    where_atts = []
+    where_atts_count = 0
+    
+    # TO BE DEFINED
+    #if params['germplasmPUI'].present? 
+    
+    if params['germplasmDbId'].present?   # plant_accessions.plant_accession
+      where_atts_count+= 1
+      where_query = where_query + "where plant_accessions.plant_accession = $"+where_atts_count.to_s
+      where_atts<< params['germplasmDbId']
+    end
+     
+    if params['germplasmName'].present?   # plant_lines.plant_variety_name or plant_common_name
+      where_atts_count+= 1
+      where_query = where_query + where_atts_count==1?" where":" and" + " (plant_lines.plant_variety_name = $"+where_atts_count.to_s+" OR 
+       plant_lines.plant_common_name = $"+where_atts_count.to_s+")"
+      where_atts<< params['germplasmName']
+    end
+    
+    
+    select_query = ""
+    
+    select_query = "SELECT DISTINCT ON (plant_accessions.id)
+    plant_accessions.id,
+    plant_accessions.user_id,
+    plant_accessions.published,
+    plant_accessions.plant_accession as \"germplasmDbId\", 
+    case 
+      when plant_lines.common_name != null then plant_lines.common_name
+      else plant_lines.plant_variety_name
+    end as \"defaultDisplayName\",
+    plant_accessions.plant_accession as \"accessionNumber\",
+    plant_lines.common_name as \"commonCropName\",
+    null as \"instituteCode\",
+    plant_accessions.originating_organisation as \"instituteName\",
+    plant_populations.population_type as \"biologicalStatusOfAccessionCode\",
+    case 
+      when countries_registered_from_lines.id != null then countries_registered_from_lines.country_code
+      else countries_registered_from_accessions.country_code
+    end as \"countryOfOriginCode\",
+    'Brassica' as \"genus\",
+    regexp_replace(taxonomy_terms.name, '( var.).*$', '') as \"species\",  
+    taxonomy_terms.name as \"subtaxa\" 
+    "
+    # TODO : instituteCode mandatory : to be implemented. To review instituteName
+    
+    
+    joins_query = "
+    FROM plant_accessions
+    INNER JOIN plant_lines ON plant_accessions.plant_line_id = plant_lines.id
+    INNER JOIN plant_population_lists ON plant_lines.id = plant_population_lists.plant_line_id
+    INNER JOIN plant_populations ON plant_population_lists.plant_population_id = plant_populations.id
+    LEFT JOIN plant_varieties AS plant_varieties_from_lines ON plant_lines.plant_variety_id = plant_varieties_from_lines.id 
+    LEFT JOIN plant_varieties AS plant_varieties_from_accessions ON plant_accessions.plant_variety_id = plant_varieties_from_accessions.id 
+    LEFT JOIN plant_variety_country_registered AS plant_variety_country_registered_from_lines ON plant_varieties_from_lines.id = plant_variety_country_registered_from_lines.plant_variety_id 
+    LEFT JOIN plant_variety_country_registered AS plant_variety_country_registered_from_accessions ON plant_varieties_from_accessions.id = plant_variety_country_registered_from_accessions.plant_variety_id 
+    LEFT JOIN countries AS countries_registered_from_lines ON plant_variety_country_registered_from_lines.country_id = countries_registered_from_lines.id 
+    LEFT JOIN countries AS countries_registered_from_accessions ON plant_variety_country_registered_from_accessions.country_id = countries_registered_from_accessions.id 
+    LEFT JOIN taxonomy_terms ON plant_lines.taxonomy_term_id = taxonomy_terms.id
+    "
+    
+    
+    # order
+    order_query =  " ORDER BY plant_accessions.id desc"
+    
+    if count_mode
+      total_query = "SELECT COUNT(*) FROM ("+select_query + joins_query + where_query + order_query+") AS total_entries_count"
+
+      puts total_query
+      result_object = execute_statement(total_query, where_atts)
+    else
+      # pagination
+      page = get_page
+      pageSize = get_pageSize
+      pagination_query = pagination_query(page, pageSize)
+      
+      total_query = select_query + joins_query + where_query + order_query + pagination_query
+      
+      json_wrapping_query = "SELECT row_to_json(row) from ("+total_query+") row"
+      
+      result_object = execute_statement(json_wrapping_query, where_atts)
+    end
+    
+    records = result_object.values
+    result_object
+  end
+
+
+  def pagination_query(page, pageSize)
+    return " LIMIT "+pageSize.to_s+" OFFSET "+((page-1)*pageSize).to_s  
+  end
+  
+  
+  def get_page
+    return (params[:page].to_i != 0)?params[:page].to_i : 1
+  end
+  
+  def get_pageSize
+    return (params[:pageSize].to_i != 0)?params[:pageSize].to_i : 1000 
+  end
+  
+  def json_metadata(pageSize, currentPage, totalCount, totalPages)
+    json_metadata = {
+      status: [],
+      files: [],
+      pagination: {
+        pageSize: pageSize, # old 'per_page'
+        currentPage:  currentPage, # old 'page'
+        totalCount: totalCount, # old 'total_count'
+        totalPages: totalPages 
+      }
+    }
+  end
+  
+
+
+  def authenticate_api_key!
+    unless api_key_token.present?
+      render json: '{"reason": "BIP API requires API key authentication"}', status: 401
+      return
+    end
+    unless api_key.present?
+      if api_key_token == I18n.t('api.general.demo_key')
+        render json: '{"reason": "Please use your own, personal API key"}', status: 401
+      else
+        render json: '{"reason": "Invalid API key"}', status: 401
+      end
+    end
+  end
+
+  def api_key_token
+    return @api_key_token if defined?(@api_key_token)
+    token = params[:api_key] || request.headers["X-BIP-Api-Key"]
+    @api_key_token = ApiKey.normalize_token(token)
+  end
+
+  def api_key
+    return @api_key if defined?(@api_key)
+    @api_key = api_key_token && ApiKey.find_by(token: api_key_token)
+  end
+
+
+  
+  def execute_statement(sql, atts)
+      connection = ActiveRecord::Base.connection.raw_connection
+
+      connection.prepare('brapi_statement', sql)
+      
+      if( (atts != nil) && !(atts.empty?) )
+        results = connection.exec_prepared("brapi_statement", atts)
+      else
+        results = connection.exec_prepared("brapi_statement")
+      end
+      connection.exec("DEALLOCATE brapi_statement")
+
+      if results.present?
+          return results
+      else
+          return nil
+      end
+  end
+
+end

--- a/app/controllers/brapi/v1/germplasm_controller.rb
+++ b/app/controllers/brapi/v1/germplasm_controller.rb
@@ -2,14 +2,9 @@ class Brapi::V1::GermplasmController < Brapi::BaseController
 
   attr_accessor :request_params, :user
 
-  before_filter :authenticate_api_key!
+  # Authentication via ORCID is currently unsupported by BrAPI.
+  # before_filter :authenticate_api_key!
 
-
-  rescue_from 'ActiveRecord::InvalidForeignKey' do |exception|
-    message = exception.message.split("\n").try(:second)
-    attribute = message ? message[14..-1].split(')')[0] : ''
-    render json: { errors: { attribute: attribute, message: message } }, status: 422
-  end
 
   rescue_from ActionController::ParameterMissing do |exception|
     render json: { errors: { attribute: exception.param, message: exception.message } }, status: 422
@@ -18,52 +13,53 @@ class Brapi::V1::GermplasmController < Brapi::BaseController
 
 
 
- def search
+  def search
     # accepted params: germplasmPUI , germplasmDbId , germplasmName , pageSize , page
-    # domainParameters = ['germplasmPUI','germplasmDbId','germplasmName']
-    # totalParameters = domainParameters + ['pageSize','page']
     
     if !params['germplasmPUI'].present? && !params['germplasmDbId'].present? && !params['germplasmName'].present?
-      render json: { reason: 'Resource not found' }, status: :not_found
+      raise ActionController::ParameterMissing.new('Not Found')
     else 
-      result_object = germplasm_query(params, false)
+      germplasm_queries = Brapi::V1::GermplasmQueries.instance
+      page = get_page
+      page_size = get_page_size 
+          
+      result_object = germplasm_queries.germplasm_search_query(
+        params['germplasmPUI'],params['germplasmDbId'], params['germplasmName'], page, page_size, false)
+      
       records = result_object.values
-      
-      
-      if records.nil?
-        render json: { reason: 'Resource not found' }, status: :not_found
+     
+      if records.nil? || records.size ==0
+        render json: { reason: 'Resource not found' }, status: :not_found  # 404
       else
-        if records.size == 1 && records[0]!=nil && records[0] != api_key.user_id && records[1] 
-          render json: { reason: 'This is a private resource of another user' }, status: :unauthorized
-        else
-          json_result_array = []
+        
+        json_result_array = []
+        
+        # any programmatic data manipulation can be done here
+        result_object.each do |row|
+          row = JSON.parse(row["row_to_json"])
           
-          # any programmatic data manipulation can be done here
-          result_object.each do |row|
-            row = JSON.parse(row["row_to_json"])
-            puts row
-            if (!row[:user_id] || (row[:user_id]!=nil && row[:user_id] != api_key.user_id && row[:published] ))
-              json_result_array << row
-            end
-          end
-          
-          # pagination data returned
-          page = get_page
-          pageSize = get_pageSize 
-          
-          result_count_object = germplasm_query(params, true)
-          totalCount = result_count_object.values.first[0].to_i
-          totalPages = (totalCount/pageSize.to_f).ceil
-          
-          json_response = { 
-            'metadata' => json_metadata(pageSize, page, totalCount, totalPages),
-            'result' => json_result_array
-          }
-         
-          render json: json_response, :except => ["id", "user_id", "created_at", "updated_at","total_entries_count"]
+          # To check authentication and ownership when ORCID is supported by BrAPI
+          # We currently only retrieve public records. This is already done at query level
+          #if (!row[:user_id] || row[:published] )
+          json_result_array << row
+          #end
         end
-      end
+        
+        # pagination data returned
+        
+        result_count_object = germplasm_queries.germplasm_search_query(
+          params['germplasmPUI'],params['germplasmDbId'], params['germplasmName'], page, page_size, true)
+        total_count = result_count_object.values.first[0].to_i
+        total_pages = (total_count/page_size.to_f).ceil
+        
+        json_response = { 
+          'metadata' => json_metadata(page_size, page, total_count, total_pages),
+          'result' => json_result_array
+        }
+       
+        render json: json_response, :except => ["id", "user_id", "created_at", "updated_at", "total_entries_count"]
       
+      end
     
     end
   end
@@ -73,128 +69,24 @@ class Brapi::V1::GermplasmController < Brapi::BaseController
 
   private
 
-
-
-  # processing result: https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/GermplasmSearchGET.md 
-  # All possible fields to return:
-  # germplasmDbId, defaultDisplayName, accessionNumber, germplasmName, germplasmPUI, pedigree, 
-  # seedSource, synonyms, commonCropName, instituteCode, instituteName, biologicalStatusOfAccessionCode, 
-  # countryOfOriginCode, typeOfGermplasmStorageCode, genus, species, speciesAuthority, subtaxa, subtaxaAuthority, 
-  # donors, acquisitionDate
-
-  def germplasm_query(params, count_mode)
-    # where conditions
-    where_query = " "
-    where_atts = []
-    where_atts_count = 0
-    
-    # TO BE DEFINED
-    #if params['germplasmPUI'].present? 
-    
-    if params['germplasmDbId'].present?   # plant_accessions.plant_accession
-      where_atts_count+= 1
-      where_query = where_query + "where plant_accessions.plant_accession = $"+where_atts_count.to_s
-      where_atts<< params['germplasmDbId']
-    end
-     
-    if params['germplasmName'].present?   # plant_lines.plant_variety_name or plant_common_name
-      where_atts_count+= 1
-      where_query = where_query + where_atts_count==1?" where":" and" + " (plant_lines.plant_variety_name = $"+where_atts_count.to_s+" OR 
-       plant_lines.plant_common_name = $"+where_atts_count.to_s+")"
-      where_atts<< params['germplasmName']
-    end
-    
-    
-    select_query = ""
-    
-    select_query = "SELECT DISTINCT ON (plant_accessions.id)
-    plant_accessions.id,
-    plant_accessions.user_id,
-    plant_accessions.published,
-    plant_accessions.plant_accession as \"germplasmDbId\", 
-    case 
-      when plant_lines.common_name != null then plant_lines.common_name
-      else plant_lines.plant_variety_name
-    end as \"defaultDisplayName\",
-    plant_accessions.plant_accession as \"accessionNumber\",
-    plant_lines.common_name as \"commonCropName\",
-    null as \"instituteCode\",
-    plant_accessions.originating_organisation as \"instituteName\",
-    plant_populations.population_type as \"biologicalStatusOfAccessionCode\",
-    case 
-      when countries_registered_from_lines.id != null then countries_registered_from_lines.country_code
-      else countries_registered_from_accessions.country_code
-    end as \"countryOfOriginCode\",
-    'Brassica' as \"genus\",
-    regexp_replace(taxonomy_terms.name, '( var.).*$', '') as \"species\",  
-    taxonomy_terms.name as \"subtaxa\" 
-    "
-    # TODO : instituteCode mandatory : to be implemented. To review instituteName
-    
-    
-    joins_query = "
-    FROM plant_accessions
-    INNER JOIN plant_lines ON plant_accessions.plant_line_id = plant_lines.id
-    INNER JOIN plant_population_lists ON plant_lines.id = plant_population_lists.plant_line_id
-    INNER JOIN plant_populations ON plant_population_lists.plant_population_id = plant_populations.id
-    LEFT JOIN plant_varieties AS plant_varieties_from_lines ON plant_lines.plant_variety_id = plant_varieties_from_lines.id 
-    LEFT JOIN plant_varieties AS plant_varieties_from_accessions ON plant_accessions.plant_variety_id = plant_varieties_from_accessions.id 
-    LEFT JOIN plant_variety_country_registered AS plant_variety_country_registered_from_lines ON plant_varieties_from_lines.id = plant_variety_country_registered_from_lines.plant_variety_id 
-    LEFT JOIN plant_variety_country_registered AS plant_variety_country_registered_from_accessions ON plant_varieties_from_accessions.id = plant_variety_country_registered_from_accessions.plant_variety_id 
-    LEFT JOIN countries AS countries_registered_from_lines ON plant_variety_country_registered_from_lines.country_id = countries_registered_from_lines.id 
-    LEFT JOIN countries AS countries_registered_from_accessions ON plant_variety_country_registered_from_accessions.country_id = countries_registered_from_accessions.id 
-    LEFT JOIN taxonomy_terms ON plant_lines.taxonomy_term_id = taxonomy_terms.id
-    "
-    
-    
-    # order
-    order_query =  " ORDER BY plant_accessions.id desc"
-    
-    if count_mode
-      total_query = "SELECT COUNT(*) FROM ("+select_query + joins_query + where_query + order_query+") AS total_entries_count"
-
-      puts total_query
-      result_object = execute_statement(total_query, where_atts)
-    else
-      # pagination
-      page = get_page
-      pageSize = get_pageSize
-      pagination_query = pagination_query(page, pageSize)
-      
-      total_query = select_query + joins_query + where_query + order_query + pagination_query
-      
-      json_wrapping_query = "SELECT row_to_json(row) from ("+total_query+") row"
-      
-      result_object = execute_statement(json_wrapping_query, where_atts)
-    end
-    
-    records = result_object.values
-    result_object
-  end
-
-
-  def pagination_query(page, pageSize)
-    return " LIMIT "+pageSize.to_s+" OFFSET "+((page-1)*pageSize).to_s  
-  end
-  
   
   def get_page
     return (params[:page].to_i != 0)?params[:page].to_i : 1
   end
   
-  def get_pageSize
+  def get_page_size
     return (params[:pageSize].to_i != 0)?params[:pageSize].to_i : 1000 
   end
   
-  def json_metadata(pageSize, currentPage, totalCount, totalPages)
+  def json_metadata(page_size, current_page, total_count, total_pages)
     json_metadata = {
       status: [],
       files: [],
       pagination: {
-        pageSize: pageSize, # old 'per_page'
-        currentPage:  currentPage, # old 'page'
-        totalCount: totalCount, # old 'total_count'
-        totalPages: totalPages 
+        pageSize: page_size, # old 'per_page'
+        currentPage:  current_page, # old 'page'
+        totalCount: total_count, # old 'total_count'
+        totalPages: total_pages 
       }
     }
   end
@@ -226,25 +118,5 @@ class Brapi::V1::GermplasmController < Brapi::BaseController
     @api_key = api_key_token && ApiKey.find_by(token: api_key_token)
   end
 
-
-  
-  def execute_statement(sql, atts)
-      connection = ActiveRecord::Base.connection.raw_connection
-
-      connection.prepare('brapi_statement', sql)
-      
-      if( (atts != nil) && !(atts.empty?) )
-        results = connection.exec_prepared("brapi_statement", atts)
-      else
-        results = connection.exec_prepared("brapi_statement")
-      end
-      connection.exec("DEALLOCATE brapi_statement")
-
-      if results.present?
-          return results
-      else
-          return nil
-      end
-  end
 
 end

--- a/app/controllers/brapi/v1/germplasm_controller.rb
+++ b/app/controllers/brapi/v1/germplasm_controller.rb
@@ -2,14 +2,9 @@ class Brapi::V1::GermplasmController < Brapi::BaseController
 
   attr_accessor :request_params, :user
 
-  # Authentication via ORCID is currently unsupported by BrAPI.
-  # before_filter :authenticate_api_key!
-
-
   rescue_from ActionController::ParameterMissing do |exception|
     render json: { errors: { attribute: exception.param, message: exception.message } }, status: 422
   end
-
 
 
 
@@ -53,11 +48,11 @@ class Brapi::V1::GermplasmController < Brapi::BaseController
         total_pages = (total_count/page_size.to_f).ceil
         
         json_response = { 
-          'metadata' => json_metadata(page_size, page, total_count, total_pages),
-          'result' => json_result_array
+          metadata: json_metadata(page_size, page, total_count, total_pages),
+          result: json_result_array
         }
        
-        render json: json_response, :except => ["id", "user_id", "created_at", "updated_at", "total_entries_count"]
+        render json: json_response, except: ["id", "user_id", "created_at", "updated_at", "total_entries_count"]
       
       end
     

--- a/app/services/brapi/v1/germplasm_queries.rb
+++ b/app/services/brapi/v1/germplasm_queries.rb
@@ -1,0 +1,142 @@
+require 'singleton'
+class Brapi::V1::GermplasmQueries
+  include Singleton
+
+  def initialize
+    # Currently only one connection opened. 
+    # TODO: For the future would be good to create a connection pool.
+    @connection = ActiveRecord::Base.connection.raw_connection    
+  end
+
+  # processing result: https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/GermplasmSearchGET.md 
+  # All possible fields to return:
+  # germplasmDbId, defaultDisplayName, accessionNumber, germplasmName, germplasmPUI, pedigree, 
+  # seedSource, synonyms, commonCropName, instituteCode, instituteName, biologicalStatusOfAccessionCode, 
+  # countryOfOriginCode, typeOfGermplasmStorageCode, genus, species, speciesAuthority, subtaxa, subtaxaAuthority, 
+  # donors, acquisitionDate
+
+  def germplasm_search_query(germplasmPUI, germplasmDbId, germplasmName, page, page_size, count_mode)
+    # where conditions
+    where_query = " "
+    where_atts = []
+    where_atts_count = 0
+    
+    # TO BE DEFINED
+    #if germplasmPUI.present? 
+    
+    if germplasmDbId.present?   # plant_accessions.plant_accession
+      where_atts_count+= 1
+      where_query = where_query + "where plant_accessions.plant_accession = $"+where_atts_count.to_s
+      where_atts<< germplasmDbId
+    end
+     
+    if germplasmName.present?   # plant_lines.plant_variety_name or plant_lines.common_name
+      where_atts_count+= 1
+      where_query = where_query + (where_atts_count>0?" and ":" where ") 
+      where_query = where_query + " (plant_lines.plant_variety_name = $"+where_atts_count.to_s+
+      " OR plant_lines.common_name = $"+where_atts_count.to_s+")"
+      where_atts<< germplasmName
+    end
+    
+    # Until ORCID implementation is done, we only must retrieve published or not owned datasets
+    where_query = where_query + (where_atts_count>0?" and ":" where ") 
+    where_query = where_query + " (plant_accessions.user_id IS NULL 
+      OR plant_accessions.published = TRUE) "
+    
+    
+    # select clauses
+    
+    select_query = <<-SQL.strip_heredoc
+      SELECT DISTINCT ON (plant_accessions.id)
+      plant_accessions.id,
+      plant_accessions.user_id,
+      plant_accessions.published,
+      plant_accessions.plant_accession as "germplasmDbId", 
+      case 
+        when plant_lines.common_name != null then plant_lines.common_name
+        else plant_lines.plant_variety_name
+      end as "defaultDisplayName",
+      plant_accessions.plant_accession as "accessionNumber",
+      plant_lines.common_name as "commonCropName",
+      null as "instituteCode",
+      plant_accessions.originating_organisation as "instituteName",
+      plant_populations.population_type as "biologicalStatusOfAccessionCode",
+      case 
+        when countries_registered_from_lines.id != null then countries_registered_from_lines.country_code
+        else countries_registered_from_accessions.country_code
+      end as "countryOfOriginCode",
+      'Brassica' as "genus",
+      regexp_replace(taxonomy_terms.name, '( var.).*$', '') as "species",  
+      taxonomy_terms.name as "subtaxa" 
+    SQL
+    
+    
+    
+    # TODO : instituteCode mandatory : to be implemented. To review instituteName
+    
+    # joins
+    
+    joins_query = "
+    FROM plant_accessions
+    INNER JOIN plant_lines ON plant_accessions.plant_line_id = plant_lines.id
+    INNER JOIN plant_population_lists ON plant_lines.id = plant_population_lists.plant_line_id
+    INNER JOIN plant_populations ON plant_population_lists.plant_population_id = plant_populations.id
+    LEFT JOIN plant_varieties AS plant_varieties_from_lines ON plant_lines.plant_variety_id = plant_varieties_from_lines.id 
+    LEFT JOIN plant_varieties AS plant_varieties_from_accessions ON plant_accessions.plant_variety_id = plant_varieties_from_accessions.id 
+    LEFT JOIN plant_variety_country_registered AS plant_variety_country_registered_from_lines ON plant_varieties_from_lines.id = plant_variety_country_registered_from_lines.plant_variety_id 
+    LEFT JOIN plant_variety_country_registered AS plant_variety_country_registered_from_accessions ON plant_varieties_from_accessions.id = plant_variety_country_registered_from_accessions.plant_variety_id 
+    LEFT JOIN countries AS countries_registered_from_lines ON plant_variety_country_registered_from_lines.country_id = countries_registered_from_lines.id 
+    LEFT JOIN countries AS countries_registered_from_accessions ON plant_variety_country_registered_from_accessions.country_id = countries_registered_from_accessions.id 
+    LEFT JOIN taxonomy_terms ON plant_lines.taxonomy_term_id = taxonomy_terms.id
+    "
+    
+    
+    if count_mode
+      total_query = "SELECT COUNT(*) FROM ("+select_query + joins_query + where_query +") AS total_entries_count"
+
+      result_object = execute_statement(total_query, where_atts)
+    else
+      # order
+      order_query =  " ORDER BY plant_accessions.id desc"
+      
+      # pagination
+      pagination_query = pagination_query(page, page_size)
+      
+      total_query = select_query + joins_query + where_query + order_query + pagination_query
+
+      json_wrapping_query = "SELECT row_to_json(row) from ("+total_query+") row"
+      
+      result_object = execute_statement(json_wrapping_query, where_atts)
+    end
+    
+    result_object
+  end
+
+
+
+  private
+
+
+  def execute_statement(sql, atts)
+    results = []
+    # There should be only one 'brapi_statement' prepared and executing running at the same time,
+    # at least until the previous one has been deallocated
+    Thread.exclusive do
+      @connection.prepare('brapi_statement', sql)
+      
+      if( (atts != nil) && !(atts.empty?) )
+        results = @connection.exec_prepared("brapi_statement", atts)
+      else
+        results = @connection.exec_prepared("brapi_statement")
+      end
+      @connection.exec("DEALLOCATE brapi_statement")
+    end
+    return results
+  end
+
+  def pagination_query(page, page_size)
+    return " LIMIT "+page_size.to_s+" OFFSET "+((page-1)*page_size).to_s  
+  end
+
+
+end

--- a/app/services/brapi/v1/germplasm_queries.rb
+++ b/app/services/brapi/v1/germplasm_queries.rb
@@ -3,8 +3,6 @@ class Brapi::V1::GermplasmQueries
   include Singleton
 
   def initialize
-    # Currently only one connection opened. 
-    # TODO: For the future would be good to create a connection pool.
     @connection = ActiveRecord::Base.connection.raw_connection    
   end
 
@@ -50,7 +48,6 @@ class Brapi::V1::GermplasmQueries
       SELECT DISTINCT ON (plant_accessions.id)
       plant_accessions.id,
       plant_accessions.user_id,
-      plant_accessions.published,
       plant_accessions.plant_accession as "germplasmDbId", 
       case 
         when plant_lines.common_name != null then plant_lines.common_name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,4 +61,14 @@ Rails.application.routes.draw do
       patch ":plural_model_name/:id/revoke", to: 'resources#revoke', constraints: publishable_constraints
     end
   end
+  
+  
+  # BRAPI V1
+  namespace :brapi, defaults: { format: 'json' } do
+    namespace :v1 do
+      
+      get "germplasm-search", to: 'germplasm#search'
+          
+    end
+  end
 end

--- a/spec/controllers/brapi/v1/germplasm_controller_spec.rb
+++ b/spec/controllers/brapi/v1/germplasm_controller_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+require 'pp'
+
+RSpec.describe Brapi::V1::GermplasmController do
+  
+  # BrAPI doesn't use ORCID authentication system and WP7 hasn't agreed yet on an alternative. 
+  # We will have to work for some time without requiring authentications.
+  #
+  #context 'when unauthenticated' do
+  #  describe '#search' do
+  #
+  #    it 'withouth being authenticated you cannot obtain authorithation to do anything' do
+  #      get :search , germplasmDbId: 'hzau2003_TN077_a03'
+  #        expect(response).to have_http_status(401)
+  #    end 
+  #  end
+  #
+  #end
+  
+  context 'BrAPI without requiring authentication' do
+    let(:u1) { create :user }
+    before { sign_in u1 }
+    
+    describe '#search' do
+
+      it 'requires at least one valid search param (germplasmPUI, germplasmDbId,or germplasmName ) to work' do
+        pl1 = create(:plant_line, published: true, user: u1)
+        pp1 = create(:plant_population, name: 'test', establishing_organisation: 'test', published: true, user: u1)
+        ppl1 = create(:plant_population_list, plant_population: pp1, plant_line: pl1, published: true, user: u1)
+        pa1 = create(:plant_accession, plant_line: pl1, plant_accession: "hzau2003_TN077_a03", published: true, user: u1)
+        
+        
+        get :search,
+            wrongParameter: 'hzau2003_TN077_a03'
+        expect(response).to have_http_status(422)
+        
+        get :search,
+            germplasmDbId: 'hzau2003_TN077_a03'
+        expect(response).to have_http_status(200)
+        
+        get :search,
+            germplasmName: 'hzau2003_TN077_a03'
+        expect(response).to have_http_status(200)
+        
+        get :search,
+            germplasmDbId: 'hzau2003_TN077_a03',
+            germplasmName: 'oneNotValid'
+        expect(response).to have_http_status(404)
+         
+      end
+
+      it 'cheking query by germplasmDbId = hzau2003_TN077_a03 returns exactly 1 result' do
+        pl1 = create(:plant_line, published: true, user: u1)
+        pp1 = create(:plant_population, name: 'test', establishing_organisation: 'test', published: true, user: u1)
+        ppl1 = create(:plant_population_list, plant_population: pp1, plant_line: pl1, published: true, user: u1)
+        pa1 = create(:plant_accession, plant_line: pl1, plant_accession: "hzau2003_TN077_a03", published: true, user: u1)
+        
+        get :search,
+          format: :json,
+          germplasmDbId: "hzau2003_TN077_a03"
+          expect(response).to have_http_status(200)
+          expect((JSON.parse(response.body))['result'].size).to eq 1
+        
+      end
+      
+      it 'cheking query by germplasmDbId = hzau2003_TN077_a04 returns not acessible/found dataset' do        
+        pl1 = create(:plant_line, published: false, user: u1)
+        pp1 = create(:plant_population, name: 'test', establishing_organisation: 'test', published: false, user: u1)
+        ppl1 = create(:plant_population_list, plant_population: pp1, plant_line: pl1, published: false, user: u1)
+        pa1 = create(:plant_accession, plant_line: pl1, plant_accession: "hzau2003_TN077_a04", published: false, user: u1)
+        
+        get :search,
+          format: :json,
+          germplasmDbId: "hzau2003_TN077_a04"
+          expect(response).to have_http_status(404)
+        #
+        #json = JSON.parse(response.body)
+        #expect(json['result'].size).to eq 1
+
+      end
+      
+ 
+    end
+
+    before { sign_out u1 }
+
+  end
+
+end

--- a/spec/controllers/brapi/v1/germplasm_controller_spec.rb
+++ b/spec/controllers/brapi/v1/germplasm_controller_spec.rb
@@ -3,20 +3,6 @@ require 'pp'
 
 RSpec.describe Brapi::V1::GermplasmController do
   
-  # BrAPI doesn't use ORCID authentication system and WP7 hasn't agreed yet on an alternative. 
-  # We will have to work for some time without requiring authentications.
-  #
-  #context 'when unauthenticated' do
-  #  describe '#search' do
-  #
-  #    it 'withouth being authenticated you cannot obtain authorithation to do anything' do
-  #      get :search , germplasmDbId: 'hzau2003_TN077_a03'
-  #        expect(response).to have_http_status(401)
-  #    end 
-  #  end
-  #
-  #end
-  
   context 'BrAPI without requiring authentication' do
     let(:u1) { create :user }
     before { sign_in u1 }


### PR DESCRIPTION
As this is my first commit here, I would specially like to know if I'm structuring things well, I would have to change the way I'm doing them, or I'm missing (or not reusing) any required functionality of the application, in order to continue working in this way or not.

Finally I've created pure SQL as there are (and there will be) some specific aspects of the returned data (many entities involved but not so many fields, some entities referenced by different relations, etc.) which need some manual treatment and it can be done with a lot better performance directly in this way.
Relations between BrAPI and BIP fields are based (as far as it has been possible yet) on Annemarie's mapping work:
https://docs.google.com/spreadsheets/d/1UicLL_FghRc8X-rVpAwlDfxQdJoRaoI4RR6icpN7J-E/edit#gid=0

To be mentioned that, except a BrAPI mandatory return field as 'instituteCode' (to be studied next), and one parameter as 'germplasmPUI', germplasm-search call is currently working.