### PR TITLE
Testing travis GWAS fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.2.1
+  - 2.2
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: ruby
 rvm:
   - 2.2.1
 
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - travis_phantomjs
 
 addons:
   postgresql: "9.3"
@@ -12,6 +15,16 @@ before_install:
   - mkdir /tmp/elasticsearch
   - wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.4/elasticsearch-2.3.4.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
   - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
+  - |
+      export PHANTOMJS_VERSION=2.1.1
+      export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH
+      if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then
+        rm -rf $PWD/travis_phantomjs
+        mkdir -p $PWD/travis_phantomjs
+        wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2
+        tar -xvf phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs
+      fi
+      phantomjs -v
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres


### PR DESCRIPTION
@Nuanda I modified Travis script so that latest PhantomJS is used (2.1.1). All specs pass with the exception of intermittent failures related to elasticsearch. As a side note, PhantomJS is no longer maintained since the advent of headless Chromium. It is a bit early to switch though.

I also changed Ruby version used by Travis to 2.2 (from 2.2.1), it makes the build some 20 seconds faster (not much, I admit) because Travis uses available binary instead of installing a new version. What do you think? Keep it or revert?