### PR TITLE
Upgrade elasticsearch to 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 before_install:
   - mkdir /tmp/elasticsearch
-  - wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.4/elasticsearch-2.3.4.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
+  - wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
   - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
   - |
       export PHANTOMJS_VERSION=2.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'omniauth-orcid'
 gem 'nokogiri'
 
 gem 'elasticsearch-model'
-gem 'elasticsearch-rails', '< 2'
+gem 'elasticsearch-rails', '~> 2'
 
 gem 'reform', '~> 1.2.6'
 gem 'obo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       activesupport (> 3)
       elasticsearch (> 0.4)
       hashie
-    elasticsearch-rails (0.1.6)
+    elasticsearch-rails (2.0.1)
     elasticsearch-transport (1.0.6)
       faraday
       multi_json
@@ -434,7 +434,7 @@ DEPENDENCIES
   dotenv-rails
   draper (~> 2.1.0)
   elasticsearch-model
-  elasticsearch-rails (< 2)
+  elasticsearch-rails (~> 2)
   exception_notification
   factory_bot_rails (< 5)
   faker

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://zenodo.org/badge/DOI/10.5281/zenodo.466050.svg
 * Ruby >= 2.0
 * MRI 2.2.x
 * PostgreSQL
-* Elasticsearch 1.4.3, Java 7
+* Elasticsearch 2.4.6, Java 7
 * R >= 3.2.2
 * [GWASSER](https://github.com/kammerer/GWASSER) (forked from [cyverseuk/GWASSER](https://github.com/cyverseuk/GWASSER))
 


### PR DESCRIPTION
Many reasons to do that:
* ES 1.x is grossly outdated
* I have issues in development env
* CI runs 2.x anyway

I have already upgraded ES in production env.