### PR TITLE
Fix side-navigation in API docs

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -39,22 +39,11 @@ $ ->
     selector: '[data-toggle]'
     placement: 'top'
 
-
   bh = $('#footer').offset()
   $('.docs-sidebar').affix offset:
     top: 220
     bottom: ->
       return @bottom = - bh.top + 320
-
-  # Handles navigation through history states originating from client-side
-  # (e.g. search results)
-  if window.isSafari()
-    $(window).on 'popstate', (e) ->
-      if e.originalEvent.state != null
-        window.location.replace window.location.href
-  else
-    $(window).on 'popstate', ->
-      window.location.replace window.location.href
 
   # Email address replacer
   $('.email-link').each ->

--- a/app/assets/javascripts/search.coffee
+++ b/app/assets/javascripts/search.coffee
@@ -53,4 +53,10 @@ class Search
       window?.history?.pushState({ cause: 'search' }, null, "/?search=#{term}")
 
 $ ->
-  new Search('.search', '.search-results', '.search-example').prepare()
+  if (window.location.pathname == "/")
+    $(window).on 'popstate', (e) ->
+      # Do not interfere with anchor-link navigation
+      if window.location.hash == ""
+        window.location.replace window.location.href
+
+    new Search('.search', '.search-results', '.search-example').prepare()


### PR DESCRIPTION
JS errors were caused by broken history handling code (used only for search).

Fixes #548 