### PR TITLE
Datatable navigation extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'whenever', '~> 0.9.7'
 gem 'roo'
 gem 'roo-xls'
 gem 'writeexcel'
+gem 'scenic', '~> 1.4'
 
 # bundle exec rake doc:rails generates the API under doc/api.
 # gem 'sdoc', '~> 0.4.0',          group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,9 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
+    scenic (1.4.1)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     sexp_processor (4.4.5)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -490,6 +493,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5.0)
   rubyzip
   sass-rails (~> 4.0.3)
+  scenic (~> 1.4)
   shoulda-matchers
   simplecov
   spring

--- a/app/assets/javascripts/data_grid_specific_columns.js.coffee
+++ b/app/assets/javascripts/data_grid_specific_columns.js.coffee
@@ -92,7 +92,7 @@ window.configs =
         render: (data, type, full, meta) ->
           modelIdUrl('plant_lines', data, full[full.length - 3])
       ,
-        targets: 'plant_accessions_plant_variety_name_column'
+        targets: 'plant_varieties_plant_variety_name_column'
         render: (data, type, full, meta) ->
           modelIdUrl('plant_varieties', data, full[full.length - 2])
       ]

--- a/app/decorators/api/decorator.rb
+++ b/app/decorators/api/decorator.rb
@@ -18,7 +18,7 @@ class Api::Decorator < Draper::Decorator
       ].flatten
 
       associations.each do |association|
-        next if expanded_association?(association)
+        next if expanded_association?(association) || excluded_association?(association)
         json[association.param] = object.send(association.name).pluck(association.primary_key)
       end
     end
@@ -31,8 +31,16 @@ class Api::Decorator < Draper::Decorator
   end
 
   def expanded_association?(association)
-    object.class.respond_to?(:json_options) &&
-      object.class.json_options[:include].include?(association.name.to_sym)
+    return false unless object.class.respond_to?(:json_options)
+
+    includes = Array.wrap(object.class.json_options[:include])
+    includes.include?(association.name.to_sym)
   end
 
+  def excluded_association?(association)
+    return false unless object.class.respond_to?(:json_options)
+
+    excludes = Array.wrap(object.class.json_options[:except])
+    excludes.include?(association.name.to_sym)
+  end
 end

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -3,38 +3,13 @@ module Publishable
 
   included do
     include ActiveModel::Validations
+    include PublishableQueries
 
     validates_with PublicationValidator
-
-    scope :published, -> { where(published: true) }
-    scope :not_published, -> { where(published: false) }
-    scope :visible, ->(uid = nil) {
-      condition = "#{table_name}.user_id IS NULL OR #{table_name}.published = TRUE"
-      condition += " OR #{table_name}.user_id = #{uid}" if uid
-      where condition
-    }
-
-    scope :hidden, ->(uid = nil) {
-      condition = "#{table_name}.published = FALSE"
-      condition += " AND #{table_name}.user_id <> #{uid}" if uid
-      where condition
-    }
 
     before_validation -> {
       self.published_on ||= Time.now if published?
     }
-
-    def revocable?
-      published? && Time.now < revocable_until
-    end
-
-    def revocable_until
-      published_on + 1.week if published?
-    end
-
-    def private?
-      !(published? || user.nil?)
-    end
 
     def publish
       return if published?

--- a/app/models/concerns/publishable_queries.rb
+++ b/app/models/concerns/publishable_queries.rb
@@ -1,0 +1,31 @@
+module PublishableQueries
+  extend ActiveSupport::Concern
+
+  included do
+    scope :published, -> { where(published: true) }
+    scope :not_published, -> { where(published: false) }
+    scope :visible, ->(uid = nil) {
+      condition = "#{table_name}.user_id IS NULL OR #{table_name}.published = TRUE"
+      condition += " OR #{table_name}.user_id = #{uid}" if uid
+      where condition
+    }
+
+    scope :hidden, ->(uid = nil) {
+      condition = "#{table_name}.published = FALSE"
+      condition += " AND #{table_name}.user_id <> #{uid}" if uid
+      where condition
+    }
+
+    def revocable?
+      published? && Time.now < revocable_until
+    end
+
+    def revocable_until
+      published_on + 1.week if published?
+    end
+
+    def private?
+      !(published? || user.nil?)
+    end
+  end
+end

--- a/app/models/concerns/relatable.rb
+++ b/app/models/concerns/relatable.rb
@@ -18,8 +18,8 @@ module Relatable extend ActiveSupport::Concern
       end
     end
 
-    def self.privacy_adjusted_count_columns
-      count_columns.map do |column|
+    def self.privacy_adjusted_count_columns(except: [])
+      (count_columns - except).map do |column|
         counter_column = column.split(/ as /i)[0]
         as_column = column.split(/ as /i)[-1]
         "(#{table_name}.#{counter_column} - coalesce(#{get_related_model(counter_column)}.hidden, 0)) AS #{as_column}"
@@ -29,8 +29,8 @@ module Relatable extend ActiveSupport::Concern
     # Left outer joins all countable relations in order to deduct the number
     # of 'hidden' records (i.e. related records that are not visible to the
     # uid user).
-    def self.join_counters(query, uid = nil)
-      count_columns.each do |count_column|
+    def self.join_counters(query, uid = nil, except: [])
+      (count_columns - except).each do |count_column|
         relation = get_related_model(count_column.split(/ as /i)[0])
         related_klass = adjust_related_name(relation).classify.constantize
         fkey = reverse_relation_key(relation)

--- a/app/models/plant_accession.rb
+++ b/app/models/plant_accession.rb
@@ -19,7 +19,7 @@ class PlantAccession < ActiveRecord::Base
             length: { is: 4 },
             allow_blank: true
 
-  validate :plant_line_xor_plant_variety
+  validate :check_plant_line_xor_plant_variety
   validates :plant_line_id, presence: true, if: 'plant_variety_id.nil?'
   validates :plant_variety_id, presence: true, if: 'plant_line_id.nil?'
 
@@ -43,13 +43,6 @@ class PlantAccession < ActiveRecord::Base
 
     query = join_counters(query, uid)
     query.pluck(*(table_columns + privacy_adjusted_count_columns + ref_columns))
-  end
-
-  def plant_line_xor_plant_variety
-    if plant_line_id.present? && plant_variety_id.present?
-      errors.add(:plant_line_id, :not_with_plant_variety)
-      errors.add(:plant_variety_id, :not_with_plant_line)
-    end
   end
 
   def self.table_columns
@@ -118,4 +111,13 @@ class PlantAccession < ActiveRecord::Base
   end
 
   include Annotable
+
+  private
+
+  def check_plant_line_xor_plant_variety
+    if plant_line_id.present? && plant_variety_id.present?
+      errors.add(:plant_line_id, :not_with_plant_variety)
+      errors.add(:plant_variety_id, :not_with_plant_line)
+    end
+  end
 end

--- a/app/models/plant_accession.rb
+++ b/app/models/plant_accession.rb
@@ -1,5 +1,5 @@
 class PlantAccession < ActiveRecord::Base
-  belongs_to :plant_line
+  belongs_to :plant_line, counter_cache: true
   belongs_to :plant_variety
   belongs_to :user
 
@@ -81,6 +81,7 @@ class PlantAccession < ActiveRecord::Base
       :fetch,
       query: params_for_filter(table_columns) +
         [
+          'plant_lines.id',
           'user_id',
           'id',
           'id' => []

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -23,6 +23,7 @@ class PlantLine < ActiveRecord::Base
 
   include Filterable
   include Pluckable
+  include Relatable
   include Searchable
   include Publishable
   include TableData
@@ -71,6 +72,12 @@ class PlantLine < ActiveRecord::Base
           'id',
           'id' => []
         ]
+    ]
+  end
+
+  def self.count_columns
+    [
+      'plant_accessions_count'
     ]
   end
 

--- a/app/models/plant_variety.rb
+++ b/app/models/plant_variety.rb
@@ -14,18 +14,43 @@ class PlantVariety < ActiveRecord::Base
 
   has_many :plant_lines
   has_many :plant_accessions
+  has_many :plant_variety_accessions
 
   validates :plant_variety_name,
             presence: true,
             uniqueness: true
 
   include Filterable
-  include Pluckable
   include Searchable
+  include Relatable
   include Publishable
   include TableData
 
   default_scope { order('plant_variety_name') }
+
+  def self.table_data(params = nil, uid = nil)
+    pva_counts_subquery = PlantVarietyAccession.
+      visible(uid).
+      group(:plant_variety_id).
+      select("count(*) AS plant_variety_accessions_count, plant_variety_id")
+
+    query = all.
+      joins {[
+        pva_counts_subquery.as('plant_variety_accession_counts').
+          on { plant_varieties.id == plant_variety_accession_counts.plant_variety_id }.outer
+      ]}
+
+    query = (params && (params[:query] || params[:fetch])) ? filter(params, query) : query
+    query = query.where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
+
+    query = join_counters(query, uid, except: ['plant_accessions_count'])
+    query.pluck(*(
+      table_columns +
+      privacy_adjusted_count_columns(except: ['plant_accessions_count']) +
+      ['COALESCE(plant_variety_accessions_count, 0) AS plant_accessions_count'] +
+      ref_columns
+    ))
+  end
 
   def self.table_columns
     [
@@ -38,6 +63,12 @@ class PlantVariety < ActiveRecord::Base
       'quoted_parentage',
       'female_parent',
       'male_parent'
+    ]
+  end
+
+  def self.count_columns
+    [
+      'plant_accessions_count'
     ]
   end
 
@@ -59,8 +90,13 @@ class PlantVariety < ActiveRecord::Base
 
   def self.json_options
     {
-      include: [:countries_of_origin, :countries_registered]
+      include: [:countries_of_origin, :countries_registered],
+      except: [:plant_variety_accessions]
     }
+  end
+
+  def plant_accessions_count
+    plant_variety_accessions.count
   end
 
   include Annotable

--- a/app/models/plant_variety_accession.rb
+++ b/app/models/plant_variety_accession.rb
@@ -1,0 +1,55 @@
+# Read-only model based on a database view.
+class PlantVarietyAccession < ActiveRecord::Base
+  belongs_to :plant_variety
+  belongs_to :plant_line
+
+  include Relatable
+  include Filterable
+
+  # TODO: not really publishable but it adds required scopes
+  include Publishable
+
+  def read_only?
+    true
+  end
+
+  def self.table_columns
+    [
+      'plant_accession',
+      'plant_lines.plant_line_name',
+      'plant_varieties.plant_variety_name',
+      'plant_accession_derivation',
+      'originating_organisation',
+      'year_produced',
+      'date_harvested'
+    ]
+  end
+
+  def self.numeric_columns
+    [
+      'year_produced'
+    ]
+  end
+
+  def self.count_columns
+    [
+      'plant_scoring_units_count'
+    ]
+  end
+
+  def self.permitted_params
+    [
+      :fetch,
+      query: params_for_filter(table_columns) +
+        [
+          'plant_lines.id',
+          'plant_varieties.id',
+          'user_id',
+          'id',
+          'id' => []
+        ]
+    ]
+  end
+
+  include Annotable
+end

--- a/app/models/plant_variety_accession.rb
+++ b/app/models/plant_variety_accession.rb
@@ -1,55 +1,16 @@
-# Read-only model based on a database view.
+# Read-only model based on a database view joining plant_accessions and plant_lines.
 class PlantVarietyAccession < ActiveRecord::Base
+  include PublishableQueries
+
+  belongs_to :user
   belongs_to :plant_variety
   belongs_to :plant_line
 
-  include Relatable
-  include Filterable
-
-  # TODO: not really publishable but it adds required scopes
-  include Publishable
+  def self.read_only?
+    true
+  end
 
   def read_only?
     true
   end
-
-  def self.table_columns
-    [
-      'plant_accession',
-      'plant_lines.plant_line_name',
-      'plant_varieties.plant_variety_name',
-      'plant_accession_derivation',
-      'originating_organisation',
-      'year_produced',
-      'date_harvested'
-    ]
-  end
-
-  def self.numeric_columns
-    [
-      'year_produced'
-    ]
-  end
-
-  def self.count_columns
-    [
-      'plant_scoring_units_count'
-    ]
-  end
-
-  def self.permitted_params
-    [
-      :fetch,
-      query: params_for_filter(table_columns) +
-        [
-          'plant_lines.id',
-          'plant_varieties.id',
-          'user_id',
-          'id',
-          'id' => []
-        ]
-    ]
-  end
-
-  include Annotable
 end

--- a/app/services/api/create_params.rb
+++ b/app/services/api/create_params.rb
@@ -50,7 +50,8 @@ class Api::CreateParams
   end
 
   def blacklisted_attrs
-    %w(id user_id created_at updated_at date_entered entered_by_whom published_on)
+    %w(id user_id created_at updated_at date_entered entered_by_whom published_on) +
+      model.klass.attribute_names.select { |name| name.ends_with?("_count") }
   end
 
 end

--- a/db/migrate/20180117113934_add_plant_accessions_count_to_plant_lines.rb
+++ b/db/migrate/20180117113934_add_plant_accessions_count_to_plant_lines.rb
@@ -1,0 +1,19 @@
+class AddPlantAccessionsCountToPlantLines < ActiveRecord::Migration
+  def up
+    add_column :plant_lines, :plant_accessions_count, :integer, null: false, default: 0
+
+    PlantLine.all.each do |plant_line|
+      query = <<-SQL.strip_heredoc
+        UPDATE plant_lines
+        SET plant_accessions_count = #{plant_line.plant_accessions.count}
+        WHERE id = #{plant_line.id}
+      SQL
+
+      PlantLine.connection.execute(query)
+    end
+  end
+
+  def down
+    remove_column :plant_lines, :plant_accessions_count, :integer
+  end
+end

--- a/db/migrate/20180130131905_create_plant_variety_accessions.rb
+++ b/db/migrate/20180130131905_create_plant_variety_accessions.rb
@@ -1,0 +1,5 @@
+class CreatePlantVarietyAccessions < ActiveRecord::Migration
+  def change
+    create_view :plant_variety_accessions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -363,7 +363,7 @@ ActiveRecord::Schema.define(version: 20180228122047) do
   add_index "plant_accessions", ["user_id"], name: "index_plant_accessions_on_user_id", using: :btree
 
   create_table "plant_lines", force: :cascade do |t|
-    t.text     "plant_line_name",                    null: false
+    t.text     "plant_line_name",                       null: false
     t.text     "common_name"
     t.text     "plant_variety_name"
     t.text     "named_by_whom"
@@ -381,9 +381,10 @@ ActiveRecord::Schema.define(version: 20180228122047) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "published",           default: true, null: false
+    t.boolean  "published",              default: true, null: false
     t.string   "sequence_identifier"
     t.datetime "published_on"
+    t.integer  "plant_accessions_count", default: 0,    null: false
   end
 
   add_index "plant_lines", ["plant_line_name"], name: "plant_lines_plant_line_name_idx", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1120,4 +1120,60 @@ ActiveRecord::Schema.define(version: 20180228122047) do
   add_foreign_key "trait_scores", "plant_scoring_units", on_update: :cascade, on_delete: :nullify
   add_foreign_key "trait_scores", "trait_descriptors", on_update: :cascade, on_delete: :nullify
   add_foreign_key "trait_scores", "users", on_update: :cascade, on_delete: :nullify
+
+  create_view "plant_variety_accessions",  sql_definition: <<-SQL
+      SELECT plant_accessions.id,
+      plant_accessions.plant_accession,
+      plant_accessions.plant_accession_derivation,
+      plant_accessions.accession_originator,
+      plant_accessions.originating_organisation,
+      plant_accessions.year_produced,
+      plant_accessions.date_harvested,
+      plant_accessions.female_parent_plant_id,
+      plant_accessions.male_parent_plant_id,
+      plant_accessions.comments,
+      plant_accessions.entered_by_whom,
+      plant_accessions.date_entered,
+      plant_accessions.data_provenance,
+      plant_accessions.data_owned_by,
+      plant_accessions.confirmed_by_whom,
+      plant_accessions.plant_line_id,
+      plant_accessions.plant_scoring_units_count,
+      plant_accessions.created_at,
+      plant_accessions.updated_at,
+      plant_accessions.user_id,
+      plant_accessions.published,
+      plant_accessions.published_on,
+      plant_accessions.plant_variety_id
+     FROM plant_accessions
+    WHERE (plant_accessions.plant_variety_id IS NOT NULL)
+  UNION
+   SELECT plant_accessions.id,
+      plant_accessions.plant_accession,
+      plant_accessions.plant_accession_derivation,
+      plant_accessions.accession_originator,
+      plant_accessions.originating_organisation,
+      plant_accessions.year_produced,
+      plant_accessions.date_harvested,
+      plant_accessions.female_parent_plant_id,
+      plant_accessions.male_parent_plant_id,
+      plant_accessions.comments,
+      plant_accessions.entered_by_whom,
+      plant_accessions.date_entered,
+      plant_accessions.data_provenance,
+      plant_accessions.data_owned_by,
+      plant_accessions.confirmed_by_whom,
+      plant_accessions.plant_line_id,
+      plant_accessions.plant_scoring_units_count,
+      plant_accessions.created_at,
+      plant_accessions.updated_at,
+      plant_accessions.user_id,
+      plant_accessions.published,
+      plant_accessions.published_on,
+      plant_lines.plant_variety_id
+     FROM (plant_accessions
+       LEFT JOIN plant_lines ON ((plant_accessions.plant_line_id = plant_lines.id)))
+    WHERE (plant_accessions.plant_variety_id IS NULL);
+  SQL
+
 end

--- a/db/views/plant_variety_accessions_v01.sql
+++ b/db/views/plant_variety_accessions_v01.sql
@@ -1,0 +1,58 @@
+(
+  SELECT
+    plant_accessions.id,
+    plant_accessions.plant_accession,
+    plant_accessions.plant_accession_derivation,
+    plant_accessions.accession_originator,
+    plant_accessions.originating_organisation,
+    plant_accessions.year_produced,
+    plant_accessions.date_harvested,
+    plant_accessions.female_parent_plant_id,
+    plant_accessions.male_parent_plant_id,
+    plant_accessions.comments,
+    plant_accessions.entered_by_whom,
+    plant_accessions.date_entered,
+    plant_accessions.data_provenance,
+    plant_accessions.data_owned_by,
+    plant_accessions.confirmed_by_whom,
+    plant_accessions.plant_line_id,
+    plant_accessions.plant_scoring_units_count,
+    plant_accessions.created_at,
+    plant_accessions.updated_at,
+    plant_accessions.user_id,
+    plant_accessions.published,
+    plant_accessions.published_on,
+    plant_accessions.plant_variety_id
+  FROM plant_accessions
+  WHERE plant_accessions.plant_variety_id IS NOT NULL
+)
+UNION
+(
+  SELECT
+    plant_accessions.id,
+    plant_accessions.plant_accession,
+    plant_accessions.plant_accession_derivation,
+    plant_accessions.accession_originator,
+    plant_accessions.originating_organisation,
+    plant_accessions.year_produced,
+    plant_accessions.date_harvested,
+    plant_accessions.female_parent_plant_id,
+    plant_accessions.male_parent_plant_id,
+    plant_accessions.comments,
+    plant_accessions.entered_by_whom,
+    plant_accessions.date_entered,
+    plant_accessions.data_provenance,
+    plant_accessions.data_owned_by,
+    plant_accessions.confirmed_by_whom,
+    plant_accessions.plant_line_id,
+    plant_accessions.plant_scoring_units_count,
+    plant_accessions.created_at,
+    plant_accessions.updated_at,
+    plant_accessions.user_id,
+    plant_accessions.published,
+    plant_accessions.published_on,
+    plant_lines.plant_variety_id
+  FROM plant_accessions LEFT OUTER JOIN plant_lines
+  ON plant_accessions.plant_line_id = plant_lines.id
+  WHERE plant_accessions.plant_variety_id IS NULL
+);

--- a/spec/models/concerns/annotable_spec.rb
+++ b/spec/models/concerns/annotable_spec.rb
@@ -79,16 +79,15 @@ RSpec.describe Annotable do
 
   context 'when model is Pluckable as well' do
     it 'plucks at least the id column' do
-      annotable_tables.each do |table|
-        klass = table.singularize.camelize.constantize
-        if klass.ancestors.include? Pluckable
+      annotable_tables.
+        map { |table| [table, table.singularize.camelize.constantize] }.
+        select { |table, klass| klass.ancestors.include?(Pluckable) }.
+        each do |table, klass|
           expect(klass.ref_columns.last).to eq "#{table}.id"
           klass.destroy_all
           instances = create_list(table.singularize, 3)
-          expect(klass.pluck_columns.map(&:last)).
-            to match_array instances.map(&:id)
+          expect(klass.pluck_columns.map(&:last)).to match_array instances.map(&:id)
         end
-      end
     end
   end
 end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe ActiveRecord::Base do
     it 'does not allow ownerless unpublished records' do
       ActiveRecord::Base.send(:subclasses).
         reject { |model| model.table_name.in?(omitted_tables) }.
+        reject { |model| model.try(:read_only?) }.
         select { |model| (model.column_names & ['user_id', 'published']).length == 2 }.
         each do |model|
           record = model.new(user: nil, published: false)

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe PlantLine do
         pl.sequence_identifier,
         pl.data_owned_by,
         pl.organisation,
+        pl.plant_accessions.count,
         pl.plant_variety.id,
         pl.id
       ]

--- a/spec/models/plant_variety_spec.rb
+++ b/spec/models/plant_variety_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe PlantVariety do
     it 'gets proper data table columns' do
       pv = create(:plant_variety)
 
+      create(:plant_line, :with_has_many_associations, plant_variety: pv)
+      create(:plant_accession, plant_line: nil, plant_variety: pv)
+
       table_data = PlantVariety.table_data
       expect(table_data.count).to eq 1
       expect(table_data[0]).to eq [
@@ -53,8 +56,11 @@ RSpec.describe PlantVariety do
         pv.quoted_parentage,
         pv.female_parent,
         pv.male_parent,
+        pv.plant_variety_accessions.count,
         pv.id
       ]
+
+      expect(pv.plant_variety_accessions.count).to eq(3)
     end
 
     it 'retrieves published data only' do

--- a/spec/services/api/model_spec.rb
+++ b/spec/services/api/model_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::Model do
       pv_assocs = Api::Model.new("plant_variety").has_many_associations
       pp_assocs = Api::Model.new("plant_population").has_many_associations
 
-      expect(pv_assocs.map(&:name)).to match_array %w(plant_lines plant_accessions)
+      expect(pv_assocs.map(&:name)).to match_array %w(plant_lines plant_accessions plant_variety_accessions)
       expect(pv_assocs.first.to_h).to include(
         name: 'plant_lines',
         primary_key: 'id',


### PR DESCRIPTION
Fixes #648 

This is about linking PL -> PA and PV -> PA (everything else is already implemented). The former is pretty straightforward as this is a normal `has_many` relation. The latter however is somewhat tricky and needs to be handled in a non-standard way as the relation `PlantVariety#plant_accessions` does not include all PAs we want to show/count for a PV.

I created a read-only model `PlantVarietyAccession` based on a database view which allows for easier access to PAs both directly and indirectly related to PV. I then used this model/db view to implement `PlantVariety#table_data` and show count of all related PAs. Unfortunately, there is no easy way to use counter cache column with this approach, so the counter attribute is not cached.
 
I am not happy about naming the new relation `PlantVariety#plant_variety_accessions`, I feel that it would make more sense to swap the name with already existing `PlantVariety#plant_accessions`. However, if I did this then the name of the new model/db view would be somewhat confusing... 