### PR TITLE
Do not reference form step in submission content

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -13,7 +13,7 @@ class SubmissionsController < ApplicationController
 
   def edit
     @submission = current_user.submissions.find(params[:id])
-    @content = step_content_form(@submission, @submission.content[@submission.step])
+    @content = step_content_form(@submission, @submission.content)
     @content.valid? if params[:validate]
     @submission = decorator(@submission)
   end

--- a/app/decorators/plant_population_submission_decorator.rb
+++ b/app/decorators/plant_population_submission_decorator.rb
@@ -28,11 +28,11 @@ class PlantPopulationSubmissionDecorator < SubmissionDecorator
   end
 
   def population_name
-    @population_name ||= object.content.step01.name.presence
+    @population_name ||= object.content.name.presence
   end
 
   def establishing_organisation
-    @establishing_organisation ||= object.content.step01.establishing_organisation.presence
+    @establishing_organisation ||= object.content.establishing_organisation.presence
   end
 
   def species_name
@@ -40,11 +40,11 @@ class PlantPopulationSubmissionDecorator < SubmissionDecorator
   end
 
   def taxonomy_term
-    @taxonomy_term ||= object.content.step02.taxonomy_term.presence
+    @taxonomy_term ||= object.content.taxonomy_term.presence
   end
 
   def population_type
-    @population_type ||= object.content.step01.population_type.presence
+    @population_type ||= object.content.population_type.presence
   end
 
   def plant_lines
@@ -59,7 +59,7 @@ class PlantPopulationSubmissionDecorator < SubmissionDecorator
   end
 
   def plant_line_list
-    object.content.step03.plant_line_list || []
+    object.content.plant_line_list || []
   end
 
   def parent_line_names
@@ -77,15 +77,15 @@ class PlantPopulationSubmissionDecorator < SubmissionDecorator
   end
 
   def female_parent_line_name
-    object.content.step02.female_parent_line.presence
+    object.content.female_parent_line.presence
   end
 
   def male_parent_line_name
-    object.content.step02.male_parent_line.presence
+    object.content.male_parent_line.presence
   end
 
   def description
-    object.content.step01.description.presence || ''
+    object.content.description.presence || ''
   end
 
   def affiliation
@@ -93,19 +93,19 @@ class PlantPopulationSubmissionDecorator < SubmissionDecorator
   end
 
   def owned_by
-    object.content.step01.owned_by.presence
+    object.content.owned_by.presence
   end
 
   def data_owned_by
-    object.content.step04.data_owned_by.presence
+    object.content.data_owned_by.presence
   end
 
   def data_provenance
-    object.content.step04.data_provenance.presence
+    object.content.data_provenance.presence
   end
 
   def comments
-    object.content.step04.comments.presence
+    object.content.comments.presence
   end
 
   def submission_attributes

--- a/app/decorators/plant_trial_submission_decorator.rb
+++ b/app/decorators/plant_trial_submission_decorator.rb
@@ -28,11 +28,11 @@ class PlantTrialSubmissionDecorator < SubmissionDecorator
   end
 
   def plant_trial_name
-    @plant_trial_name ||= object.content.step01.plant_trial_name.presence
+    @plant_trial_name ||= object.content.plant_trial_name.presence
   end
 
   def project_descriptor
-    @project_descriptor ||= object.content.step01.project_descriptor.presence
+    @project_descriptor ||= object.content.project_descriptor.presence
   end
 
   def species_name
@@ -41,12 +41,12 @@ class PlantTrialSubmissionDecorator < SubmissionDecorator
 
   def plant_population
     return @plant_population if defined?(@plant_population)
-    return if object.content.step01.plant_population_id.blank?
-    @plant_population = PlantPopulation.find_by(id: object.content.step01.plant_population_id)
+    return if object.content.plant_population_id.blank?
+    @plant_population = PlantPopulation.find_by(id: object.content.plant_population_id)
   end
 
   def trait_descriptors
-    tds = object.content.step02.trait_descriptor_list.try(:select, &:present?) || []
+    tds = object.content.trait_descriptor_list.try(:select, &:present?) || []
     existing_tds = tds.select { |td| td.to_s.match(/\A\d+\z/) }
     new_tds = tds - existing_tds
     new_tds | TraitDescriptor.includes(:trait).references(:trait).where(id: existing_tds).pluck('traits.name')
@@ -55,7 +55,7 @@ class PlantTrialSubmissionDecorator < SubmissionDecorator
   # Takes new TD names and hits the DB for old TDs for their names; sorts
   def sorted_trait_names
     return @sorted_trait_names if @sorted_trait_names
-    trait_list = object.content.step02.trait_descriptor_list || []
+    trait_list = object.content.trait_descriptor_list || []
     @sorted_trait_names = trait_list.compact.map do |trait_item|
       if trait_item.to_i.to_s != trait_item.to_s
         trait_item
@@ -71,15 +71,15 @@ class PlantTrialSubmissionDecorator < SubmissionDecorator
   end
 
   def plant_trial_description
-    object.content.step01.plant_trial_description
+    object.content.plant_trial_description
   end
 
   def trial_year
-    object.content.step01.trial_year
+    object.content.trial_year
   end
 
   def country_name
-    country_id = object.content.step01.country_id
+    country_id = object.content.country_id
     return unless country_id.present?
     Country.find(country_id).country_name
   end
@@ -89,53 +89,53 @@ class PlantTrialSubmissionDecorator < SubmissionDecorator
   end
 
   def institute_id
-    object.content.step01.institute_id
+    object.content.institute_id
   end
 
   def trial_location_site_name
-    object.content.step01.trial_location_site_name
+    object.content.trial_location_site_name
   end
 
   def place_name
-    object.content.step01.place_name
+    object.content.place_name
   end
 
   def latitude
-    object.content.step01.latitude
+    object.content.latitude
   end
 
   def longitude
-    object.content.step01.longitude
+    object.content.longitude
   end
 
   def altitude
-    alt = object.content.step01.altitude
+    alt = object.content.altitude
     return unless alt.present?
     "#{alt} m"
   end
 
   def terrain
-    object.content.step01.terrain
+    object.content.terrain
   end
 
   def soil_type
-    object.content.step01.soil_type
+    object.content.soil_type
   end
 
   def statistical_factors
-    object.content.step01.statistical_factors
+    object.content.statistical_factors
   end
 
   def data_owned_by
-    object.content.step06.data_owned_by.presence
+    object.content.data_owned_by.presence
   end
 
   def data_provenance
-    object.content.step06.data_provenance.presence
+    object.content.data_provenance.presence
   end
 
   def comments
-    object.content.step06.comments.presence
+    object.content.comments.presence
   end
 
   def layout_url
@@ -151,15 +151,15 @@ class PlantTrialSubmissionDecorator < SubmissionDecorator
   end
 
   def raw_data?
-    object.content.step01.data_status == 'raw_data'
+    object.content.data_status == 'raw_data'
   end
 
   def technical_replicate_numbers
-    object.content.step03.technical_replicate_numbers.presence || []
+    object.content.technical_replicate_numbers.presence || []
   end
 
   def design_factor_names
-    object.content.step03.design_factor_names || []
+    object.content.design_factor_names || []
   end
 
   def submission_attributes

--- a/app/decorators/submission_plant_lines_upload_decorator.rb
+++ b/app/decorators/submission_plant_lines_upload_decorator.rb
@@ -6,6 +6,6 @@ class SubmissionPlantLinesUploadDecorator < SubmissionUploadDecorator
   private
 
   def uploaded_plant_lines
-    submission.content.step03.uploaded_plant_lines
+    submission.content.uploaded_plant_lines
   end
 end

--- a/app/decorators/submission_trait_scores_upload_decorator.rb
+++ b/app/decorators/submission_trait_scores_upload_decorator.rb
@@ -151,11 +151,11 @@ class SubmissionTraitScoresUploadDecorator < SubmissionUploadDecorator
   end
 
   def accessions
-    object.submission.content.step04.accessions
+    object.submission.content.accessions
   end
 
   def lines_or_varieties
-    submission.content.step04.lines_or_varieties || {}
+    submission.content.lines_or_varieties || {}
   end
 
   def trait_names
@@ -163,14 +163,14 @@ class SubmissionTraitScoresUploadDecorator < SubmissionUploadDecorator
   end
 
   def trait_mapping
-    object.submission.content.step04.trait_mapping
+    object.submission.content.trait_mapping
   end
 
   def replicate_numbers
-    object.submission.content.step04.replicate_numbers
+    object.submission.content.replicate_numbers
   end
 
   def trait_scores
-    object.submission.content.step04.trait_scores || {}
+    object.submission.content.trait_scores || {}
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -34,8 +34,10 @@ class Submission < ActiveRecord::Base
   end
 
   def content_for?(step)
+    return false if content.last_step.blank?
+
     step = steps[step.to_i] if step.to_s =~ /\A\d+\z/
-    content[step].to_h.present?
+    steps.index(step.to_s) <= steps.index(content.last_step)
   end
 
   def step_forward
@@ -128,14 +130,11 @@ class Submission < ActiveRecord::Base
     return unless trial?
     return unless content_changed?
 
-    step02_was = content_was[:step02] || {}
-    step02 = content[:step02] || {}
-
-    old_trait_descriptor_list = (step02_was[:trait_descriptor_list] || []).map(&:to_s)
-    new_trait_descriptor_list = (step02[:trait_descriptor_list] || []).map(&:to_s)
+    old_trait_descriptor_list = (content_was[:trait_descriptor_list] || []).map(&:to_s)
+    new_trait_descriptor_list = (content[:trait_descriptor_list] || []).map(&:to_s)
 
     if old_trait_descriptor_list != new_trait_descriptor_list
-      content.clear(:step04)
+      content.clear(:upload_id)
     end
   end
 

--- a/app/models/submission/content.rb
+++ b/app/models/submission/content.rb
@@ -2,57 +2,74 @@ class Submission::Content < OpenStruct
   def initialize(submission)
     self.submission = submission
 
-    pairs = submission.read_attribute(:content).map { |step, step_content| [step, OpenStruct.new(step_content)] }
-    pairs = Hash[pairs]
-    submission.steps.each { |step| pairs[step] = OpenStruct.new unless pairs.key?(step) }
-    super(pairs)
+    super(read_content)
   end
 
-  def update(step, step_content)
+  def update(step, new_content)
     raise Submission::InvalidStep, "No step #{step}" unless submission.steps.include?(step.to_s)
-    step_content = sanitize(step_content.to_h)
-    current_step_content = submission.read_attribute(:content)[step.to_s] || {}
 
-    submission.content = submission.
-      read_attribute(:content).
-      merge(step => current_step_content.merge(step_content.stringify_keys))
+    new_content = sanitize(new_content.to_h)
+    current_content = read_content
+    current_content["last_step"] = step if update_step?(step)
+
+    submission.content = current_content.merge(new_content.stringify_keys)
   end
 
-  def append(step, step_content)
+  def append(step, new_content)
     raise Submission::InvalidStep, "No step #{step}" unless submission.steps.include?(step.to_s)
-    step_content = sanitize(step_content.to_h)
-    current_step_content = submission.read_attribute(:content)[step.to_s] || {}
 
-    step_content.stringify_keys.each do |attr, val|
-      current_val = current_step_content[attr] || val.class.new
+    new_content = sanitize(new_content.to_h)
+    current_content = read_content
+    current_content["last_step"] = step if update_step?(step)
+
+    new_content.stringify_keys.each do |attr, val|
+      current_val = current_content[attr]
 
       if val.is_a?(Hash) && current_val.is_a?(Hash)
-        step_content[attr] = current_val.merge(val)
+        new_content[attr] = current_val.merge(val)
       elsif val.is_a?(Array) && current_val.is_a?(Array)
-        step_content[attr] = current_val | val
-      else
+        new_content[attr] = current_val | val
+      elsif current_val
         raise "Cannot append content for '#{attr}'"
       end
     end
 
-    submission.content = submission.read_attribute(:content).merge(step => step_content)
+    submission.content = current_content.merge(new_content.stringify_keys)
   end
 
-  def clear(step)
-    raise Submission::InvalidStep, "No step #{step}" unless submission.steps.include?(step.to_s)
-    submission.content = submission.
-      read_attribute(:content).
-      merge(step => {})
+  def clear(attr)
+    current_content = read_content
+    current_content.delete(attr.to_s)
+
+    submission.content = current_content
+  end
+
+  def to_h
+    super.except(*restricted_attrs.map(&:to_sym))
   end
 
   private
+
   attr_accessor :submission
 
-  def sanitize(step_content)
-    step_content.each do |attr, val|
+  def read_content
+    submission.read_attribute(:content) || {}
+  end
+
+  def sanitize(content)
+    content.each do |attr, val|
+      fail ArgumentError, "Property '#{attr}' is restricted" if restricted_attrs.include?(attr.to_s)
       if val.is_a?(Array)
-        step_content[attr] = val.select(&:present?)
+        content[attr] = val.select(&:present?)
       end
     end
+  end
+
+  def update_step?(step)
+    last_step.nil? || submission.steps.index(step.to_s) > submission.steps.index(last_step)
+  end
+
+  def restricted_attrs
+    %w(last_step)
   end
 end

--- a/app/services/submission/plant_line_parser.rb
+++ b/app/services/submission/plant_line_parser.rb
@@ -155,7 +155,7 @@ class Submission::PlantLineParser
   end
 
   def current_plant_lines
-    @current_plant_lines ||= @upload.submission.content.step03.plant_line_list || []
+    @current_plant_lines ||= @upload.submission.content.plant_line_list || []
   end
 
   def header_columns

--- a/app/services/submission/trait_score_template_generator.rb
+++ b/app/services/submission/trait_score_template_generator.rb
@@ -8,20 +8,20 @@ class Submission::TraitScoreTemplateGenerator
   def call
     traits = PlantTrialSubmissionDecorator.decorate(@submission).sorted_trait_names
 
-    pl_pv_name = if @submission.content.step03.lines_or_varieties == 'plant_varieties'
+    pl_pv_name = if @submission.content.lines_or_varieties == 'plant_varieties'
                    'variety'
                  else
                    'line'
                  end
 
-    design_factor_names = @submission.content.step03.design_factor_names || []
+    design_factor_names = @submission.content.design_factor_names || []
     design_factors = {
       'A' => design_factor_names.map{ '1 - replace it' },
       'B' => design_factor_names.map{ '1 - replace it' }
     }
     design_factors['B'][-1] = '2 - replace it' if design_factors['B'].present?
 
-    technical_replicate_numbers = @submission.content.step03.technical_replicate_numbers || {}
+    technical_replicate_numbers = @submission.content.technical_replicate_numbers || {}
     traits = traits.map.with_index do |trait, idx|
       if technical_replicate_numbers[idx] && technical_replicate_numbers[idx].to_i > 1
         reps_count = [technical_replicate_numbers[idx].to_i, 2].max

--- a/app/views/submissions/steps/trial/_step04_before.html.haml
+++ b/app/views/submissions/steps/trial/_step04_before.html.haml
@@ -1,7 +1,7 @@
 - pl_pv_name = 'line'
-- pl_pv_name = 'variety' if submission.content.step03.lines_or_varieties == 'plant_varieties'
-- design_factor_names = submission.content.step03.design_factor_names || []
-- technical_replicate_numbers = submission.content.step03.technical_replicate_numbers || {}
+- pl_pv_name = 'variety' if submission.content.lines_or_varieties == 'plant_varieties'
+- design_factor_names = submission.content.design_factor_names || []
+- technical_replicate_numbers = submission.content.technical_replicate_numbers || {}
 - rep_traits = technical_replicate_numbers.select{ |k,v| v.to_i > 1 }.to_a
 
 .info-block

--- a/db/migrate/20180202171044_remove_steps_from_submission_content.rb
+++ b/db/migrate/20180202171044_remove_steps_from_submission_content.rb
@@ -1,0 +1,13 @@
+class RemoveStepsFromSubmissionContent < ActiveRecord::Migration
+  def up
+    Submission.all.each do |submission|
+      submission.update!(content: submission.content.to_h.values.reduce({}) { |sum, step| sum.merge(step) })
+      submission.content.update(submission.step, {})
+      submission.save!
+    end
+  end
+
+  def down
+    fail ActiveRecordd::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 20170929085416) do
+ActiveRecord::Schema.define(version: 20180202171044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -32,8 +32,8 @@ FactoryBot.define do
 
           submission.step = :step04
 
-          FactoryBot.create(:taxonomy_term, name: submission.content.step02.taxonomy_term)
-          FactoryBot.create(:population_type, population_type: submission.content.step01.population_type)
+          FactoryBot.create(:taxonomy_term, name: submission.content.taxonomy_term)
+          FactoryBot.create(:population_type, population_type: submission.content.population_type)
         elsif submission.trial?
           plant_population = FactoryBot.create(:plant_population, user: submission.user)
           country = FactoryBot.create(:country)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Submission do
     end
 
     it "returns true if any content for given step is present" do
-      expect(subject.content_for?(0)).to be_falsey
+      expect(subject.content_for?(0)).to be_truthy
       expect(subject.content_for?(1)).to be_truthy
       expect(subject.content_for?(2)).to be_falsey
       expect(subject.content_for?(3)).to be_falsey
@@ -112,16 +112,18 @@ RSpec.describe Submission do
   describe '#content' do
     before {
       subject.content = {
-        :step01 => { :foo => 1, :bar => "ble" },
-        :step02 => { :baz => [1, 2, 3], :blah => {} }
+        foo: 1,
+        bar: "ble",
+        baz: [1, 2, 3],
+        blah: {}
       }
     }
 
     it 'allows to access step content' do
-      expect(subject.content.step01.foo).to eq 1
-      expect(subject.content.step01.bar).to eq "ble"
-      expect(subject.content.step02.baz).to eq [1, 2, 3]
-      expect(subject.content.step02.blah).to eq({})
+      expect(subject.content.foo).to eq 1
+      expect(subject.content.bar).to eq "ble"
+      expect(subject.content.baz).to eq [1, 2, 3]
+      expect(subject.content.blah).to eq({})
     end
   end
 
@@ -229,25 +231,26 @@ RSpec.describe Submission do
       submission.save!
     end
 
-    it "clears step04 of trial submission if step02 content is changed" do
-      expect(submission.content.step04.to_h).not_to be_blank
+    it "clears :upload_if of trial submission if step02 content is changed" do
+      expect(submission.content.upload_id).not_to be_blank
       submission.content.update(:step02, trait_descriptor_list: ["trait X"])
       submission.save!
-      expect(submission.reload.content.step04.to_h).to be_blank
+      expect(submission.reload.content.upload_id).to be_blank
     end
 
-    it "does not clear step04 of trial submission if step02 content is not changed" do
-      expect(submission.content.step04.to_h).not_to be_blank
+    it "does not clear :upload_id of trial submission if step02 content is not changed" do
+      expect(submission.content.upload_id).not_to be_blank
       submission.content.update(:step02, trait_descriptor_list: [])
       submission.save!
-      expect(submission.reload.content.step04.to_h).not_to be_blank
+      expect(submission.reload.content.upload_id).not_to be_blank
     end
 
-    it "leaves step06 of trial submission intact if step02 content is changed" do
-      expect(submission.content.step06.to_h).not_to be_blank
-      submission.content.update(:step02, trait_descriptor_list: ["trait X"])
-      submission.save!
-      expect(submission.reload.content.step06.to_h).not_to be_blank
+    it "leaves the rest of trial submission intact if step02 content is changed" do
+      expect(submission.content.to_h.except(:upload_id)).not_to be_blank
+      expect do
+        submission.content.update(:step02, trait_descriptor_list: ["trait X"])
+        submission.save!
+      end.not_to change { submission.content.to_h.except(:upload_id, :trait_descriptor_list) }
     end
   end
 end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "Submission management" do
 
           it "ignores not-permitted params" do
             put "/submissions/#{submission.id}", submission: { content: { unknown_property: true } }
-            expect(submission.reload.content.step01.unknown_property).to be nil
+            expect(submission.reload.content.unknown_property).to be nil
           end
 
           it "can be traversed from first to last step and finalized" do
@@ -194,7 +194,7 @@ RSpec.describe "Submission management" do
                                   end
 
               put "/submissions/#{submission.id}", step_params
-              expect(submission.reload.content.send(step).to_h).to include(step_params[:submission][:content])
+              expect(submission.reload.content.to_h).to include(step_params[:submission][:content])
               expect(response).to redirect_to(expected_redirect)
             end
 

--- a/spec/services/submission/plant_line_parser_spec.rb
+++ b/spec/services/submission/plant_line_parser_spec.rb
@@ -187,8 +187,8 @@ RSpec.describe Submission::PlantLineParser do
 
     it 'assigns step03 content with parsed information' do
       subject.call
-      expect(upload.submission.content.step03.plant_line_list).to eq ['pl_ok_newpv_newpa', 'pl_ok_nopa']
-      expect(upload.submission.content.step03.new_plant_lines).to eq [
+      expect(upload.submission.content.plant_line_list).to eq ['pl_ok_newpv_newpa', 'pl_ok_nopa']
+      expect(upload.submission.content.new_plant_lines).to eq [
         {
           'plant_line_name' => 'pl_ok_newpv_newpa',
           'plant_variety_name' => 'Alesi',
@@ -208,13 +208,13 @@ RSpec.describe Submission::PlantLineParser do
           'sequence_identifier' => 'SRR3134398'
         }
       ]
-      expect(upload.submission.content.step03.new_plant_varieties).to eq({
+      expect(upload.submission.content.new_plant_varieties).to eq({
         'pl_ok_newpv_newpa' => {
           'plant_variety_name' => 'Alesi',
           'crop_type' => 'Winter oilseed rape'
         }
       })
-      expect(upload.submission.content.step03.new_plant_accessions).to eq({
+      expect(upload.submission.content.new_plant_accessions).to eq({
         'pl_ok_newpv_newpa' => {
           'plant_accession' => 'New accession X',
           'originating_organisation' => 'EI',

--- a/spec/services/submission/plant_trial_finalizer_spec.rb
+++ b/spec/services/submission/plant_trial_finalizer_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Submission::PlantTrialFinalizer do
     context 'when dealing with plant lines and plant varieties' do
       it 'creates or assigns plant varieties for new accessions only' do
         submission.content.update(:step04,
-          submission.content.step03.to_h.merge(
+          submission.content.to_h.merge(
             lines_or_varieties: {
               'p1' => { relation_class_name: 'PlantVariety', relation_record_name: 'New variety to be created' },
               'p2' => { relation_class_name: 'PlantVariety', relation_record_name: 'New variety not to be created' },
@@ -204,7 +204,7 @@ RSpec.describe Submission::PlantTrialFinalizer do
 
       it 'assigns plant lines for new accessions only' do
         submission.content.update(:step04,
-          submission.content.step03.to_h.merge(
+          submission.content.to_h.merge(
             lines_or_varieties: {
               'p1' => { relation_class_name: 'PlantLine', relation_record_name: existing_line.plant_line_name },
               'p2' => { relation_class_name: 'PlantLine', relation_record_name: 'New line not to be created' },
@@ -224,7 +224,7 @@ RSpec.describe Submission::PlantTrialFinalizer do
 
       it 'does not mind nil PL/PV values for existing accession PSUs' do
         submission.content.update(:step04,
-          submission.content.step03.to_h.merge(
+          submission.content.to_h.merge(
             trait_scores: {
               'p1' => {}
             },
@@ -246,7 +246,7 @@ RSpec.describe Submission::PlantTrialFinalizer do
         # We let nil PV/PL through the parser, for existing PA.
         # So we need to check in the finalizer if they still exist
         submission.content.update(:step04,
-          submission.content.step03.to_h.merge(
+          submission.content.to_h.merge(
             lines_or_varieties: {
               'p1' => { relation_class_name: 'PlantVariety', relation_record_name: nil },
               'p2' => { relation_class_name: 'PlantVariety', relation_record_name: nil },
@@ -264,7 +264,7 @@ RSpec.describe Submission::PlantTrialFinalizer do
     context 'when parsing technical replicate data' do
       before :each do
         submission.content.update(:step04,
-          submission.content.step03.to_h.merge(
+          submission.content.to_h.merge(
             trait_mapping: { 0 => 0, 1 => 0, 2 => 1, 3 => 2, 4 => 2 },
             replicate_numbers: { 0 => 1, 1 => 2, 2 => 0, 3 => 1, 4 => 2 },
             trait_scores: {
@@ -296,7 +296,7 @@ RSpec.describe Submission::PlantTrialFinalizer do
     context 'when parsing design factors' do
       before :each do
         submission.content.update(:step04,
-          submission.content.step03.to_h.merge(
+          submission.content.to_h.merge(
             design_factor_names: ['polytunnel', 'rep', 'sub_block', 'pot_number'],
             design_factors: {
               'p1' => ['A', '1', '1', '1'],

--- a/spec/services/submission/trait_score_parser_spec.rb
+++ b/spec/services/submission/trait_score_parser_spec.rb
@@ -389,13 +389,13 @@ RSpec.describe Submission::TraitScoreParser do
       upload.submission.content.update(:step04, trait_scores: { 'plant' => { 1 => '5' }})
       input_is ''
       subject.call
-      expect(upload.submission.content.step04.trait_scores).to be_nil
-      expect(upload.submission.content.step04.trait_mapping).to be_nil
-      expect(upload.submission.content.step04.replicate_numbers).to be_nil
-      expect(upload.submission.content.step04.design_factors).to be_nil
-      expect(upload.submission.content.step04.design_factor_names).to be_nil
-      expect(upload.submission.content.step04.accessions).to be_nil
-      expect(upload.submission.content.step04.lines_or_varieties).to be_nil
+      expect(upload.submission.content.trait_scores).to be_nil
+      expect(upload.submission.content.trait_mapping).to be_nil
+      expect(upload.submission.content.replicate_numbers).to be_nil
+      expect(upload.submission.content.design_factors).to be_nil
+      expect(upload.submission.content.design_factor_names).to be_nil
+      expect(upload.submission.content.accessions).to be_nil
+      expect(upload.submission.content.lines_or_varieties).to be_nil
     end
 
     it 'ignores any score in index grater than traits number' do


### PR DESCRIPTION
I need to change the structure of submission forms again. Before doing that I decided to change the way submission content is stored - it won't be nested under step name anymore:

```ruby
# before
submission.content.step01.plant_trial_name

# after
submission.content.plant_trial_name
```

I don't think having this nesting benefited us anyway and removing it will save me the trouble with migration of data between the respective steps. 