### PR TITLE
Existing plant lines upload

### DIFF
--- a/app/assets/javascripts/components/plant_population_submission.coffee
+++ b/app/assets/javascripts/components/plant_population_submission.coffee
@@ -173,6 +173,11 @@ window.PlantPopulationSubmission = class PlantPopulationSubmission extends Submi
             $li = $("<li></li>").text(error)
             $errors.find("ul").append($li)
           )
+        else
+          @$('.fileinput-button').removeClass('disabled')
+
+          $errors = $(".errors").text("").removeClass('hidden').append("<ul></ul>")
+          $errors.find("ul").append($("<li></li>").text("Unexpected server response: #{data.jqXHR.status} #{data.jqXHR.statusText}"))
 
     @$('.delete-plant-lines-upload').on 'ajax:success', (data, status, xhr) =>
       @$('.fileinput').removeClass('hidden')

--- a/app/assets/javascripts/components/plant_population_submission.coffee
+++ b/app/assets/javascripts/components/plant_population_submission.coffee
@@ -89,7 +89,8 @@ window.PlantPopulationSubmission = class PlantPopulationSubmission extends Submi
 
   hasNewPlantLine: (data) =>
     fieldName = "submission[content][new_plant_lines][][plant_line_name]"
-    $("[name='#{fieldName}'][value='#{data.plant_line_name}']").length > 0
+    selector = "[name='#{fieldName}'][value='#{data.plant_line_name}']"
+    $(selector).length > 0
 
   hasExistingPlantLine: (data) =>
     $("#submission_content_plant_line_list option[value='#{data.id}']").length > 0
@@ -107,7 +108,7 @@ window.PlantPopulationSubmission = class PlantPopulationSubmission extends Submi
 
   appendNewPlantLineData: (data) =>
     # add all PL attributes to DOM so it can be sent with form
-    $form = @$el.find('form')
+    $form = @$el.find('form.edit-submission')
     $container = $('<div></div>').attr(id: @newPlantLineForListContainerId(data.plant_line_name), class: "new-plant-line-attrs")
     $container.appendTo($form)
 
@@ -127,7 +128,7 @@ window.PlantPopulationSubmission = class PlantPopulationSubmission extends Submi
     this.resetNewPlantLines() if $select.find("option").length == 0
 
   resetNewPlantLines: =>
-    $form = @$el.find('form')
+    $form = @$el.find('form.edit-submission')
     $form.find(".new-plant-line-attrs").remove()
 
     $container = $('<div></div>').attr(id: @newPlantLineForListContainerId(""), class: "new-plant-line-attrs")
@@ -163,13 +164,15 @@ window.PlantPopulationSubmission = class PlantPopulationSubmission extends Submi
           @$('.uploaded-plant-lines .parser-errors').addClass('hidden')
           @$('.uploaded-plant-lines .parser-errors').text('')
 
+
           $.each(data.result.uploaded_new_plant_lines, (_, plantLineData) =>
-            unless @hasNewPlantLine(plantLineData)
-              @appendToSelectedPlantLineLists(plantLineData)
-              @appendNewPlantLineData(plantLineData)
+            @removeNewPlantLineFromList(plantLineData.plant_line_name) if @hasNewPlantLine(plantLineData)
+            @appendToSelectedPlantLineLists(plantLineData)
+            @appendNewPlantLineData(plantLineData)
           )
 
           $.each(data.result.uploaded_existing_plant_lines, (_, plantLineData) =>
+            @removeNewPlantLineFromList(plantLineData.plant_line_name) if @hasNewPlantLine(plantLineData)
             @appendToSelectedPlantLineLists(plantLineData) unless @hasExistingPlantLine(plantLineData)
           )
 

--- a/app/assets/javascripts/components/plant_trial_submission.coffee
+++ b/app/assets/javascripts/components/plant_trial_submission.coffee
@@ -90,6 +90,11 @@ window.PlantTrialSubmission = class PlantTrialSubmission extends Submission
             $li = $("<li></li>").text(error)
             $errors.find("ul").append($li)
           )
+        else
+          @$('.fileinput-button').removeClass('disabled')
+
+          $errors = $(".errors").text("").removeClass('hidden').append("<ul></ul>")
+          $errors.find("ul").append($("<li></li>").text("Unexpected server response: #{data.jqXHR.status} #{data.jqXHR.statusText}"))
 
     @$('.delete-trait-scores-upload').on 'ajax:success', (data, status, xhr) =>
       @$('.fileinput').removeClass('hidden')
@@ -128,6 +133,11 @@ window.PlantTrialSubmission = class PlantTrialSubmission extends Submission
             $li = $("<li></li>").text(error)
             $errors.find("ul").append($li)
           )
+        else
+          @$('.fileinput-button').removeClass('disabled')
+
+          $errors = $(".errors").text("").removeClass('hidden').append("<ul></ul>")
+          $errors.find("ul").append($("<li></li>").text("Unexpected server response: #{data.jqXHR.status} #{data.jqXHR.statusText}"))
 
     @$('.delete-layout-upload').on 'ajax:success', (data, status, xhr) =>
       @$('.fileinput').removeClass('hidden')

--- a/app/assets/javascripts/submissions.coffee
+++ b/app/assets/javascripts/submissions.coffee
@@ -1,4 +1,5 @@
 $ ->
-  new PlantPopulationSubmission('.edit-population-submission').init()
+  window.pp = new PlantPopulationSubmission('.edit-population-submission')
+  window.pp.init()
   new PlantTrialSubmission('.edit-trial-submission').init()
 

--- a/app/decorators/submission_plant_lines_upload_decorator.rb
+++ b/app/decorators/submission_plant_lines_upload_decorator.rb
@@ -1,11 +1,30 @@
 class SubmissionPlantLinesUploadDecorator < SubmissionUploadDecorator
   def as_json(*)
-    super.merge(uploaded_plant_lines: uploaded_plant_lines)
+    super.merge(uploaded_existing_plant_lines: uploaded_existing_plant_lines,
+                uploaded_new_plant_lines: uploaded_new_plant_lines)
   end
 
   private
 
   def uploaded_plant_lines
-    submission.content.uploaded_plant_lines
+    submission.content.uploaded_plant_lines || []
+  end
+
+  def new_plant_lines
+    submission.content.new_plant_lines || []
+  end
+
+  def uploaded_existing_plant_lines
+    PlantLine.
+      visible(submission.user_id).
+      where(plant_line_name: uploaded_plant_lines).
+      pluck(:id, :plant_line_name).
+      map { |id, plant_line_name| { id: id, plant_line_name: plant_line_name } }
+  end
+
+  def uploaded_new_plant_lines
+    new_plant_lines.select do |plant_line_attrs|
+      uploaded_plant_lines.include?(plant_line_attrs.fetch("plant_line_name"))
+    end
   end
 end

--- a/app/forms/submissions/population/step03_content_form.rb
+++ b/app/forms/submissions/population/step03_content_form.rb
@@ -23,7 +23,7 @@ module Submissions
       # Do not allow :new_plant_lines to include existing :plant_line_name
       validate do
         new_plant_lines.each do |new_plant_line|
-          if plant_line_exists?("plant_line_name ILIKE ?", new_plant_line.plant_line_name)
+          if plant_line_exists?(plant_line_name: new_plant_line.plant_line_name)
             errors.add(:new_plant_lines, :taken, name: new_plant_line.plant_line_name)
           end
         end

--- a/app/services/submission/plant_line_parser.rb
+++ b/app/services/submission/plant_line_parser.rb
@@ -1,6 +1,6 @@
 class Submission::PlantLineParser
 
-  attr_reader :plant_lines
+  attr_reader :plant_line_names, :new_plant_lines, :new_plant_varieties, :new_plant_accessions
 
   def initialize(upload)
     @upload = upload
@@ -20,11 +20,11 @@ class Submission::PlantLineParser
 
     if @upload.errors.empty?
       @upload.submission.content.append(:step03,
-                                        plant_line_list: plant_line_names,
-                                        new_plant_lines: @plant_lines,
-                                        new_plant_varieties: @plant_varieties,
-                                        new_plant_accessions: @plant_accessions)
-      @upload.submission.content.update(:step03, uploaded_plant_lines: @plant_lines)
+                                        plant_line_list: @plant_line_names,
+                                        new_plant_lines: @new_plant_lines,
+                                        new_plant_varieties: @new_plant_varieties,
+                                        new_plant_accessions: @new_plant_accessions)
+      @upload.submission.content.update(:step03, uploaded_plant_lines: @plant_line_names)
       @upload.submission.save!
       @upload.submission.content.save!
     end
@@ -48,38 +48,35 @@ class Submission::PlantLineParser
 
   def parse_plant_lines
     @upload.log "Parsing Plant Lines data"
-    @plant_lines = []
-    @plant_varieties = {}
-    @plant_accessions = {}
+    @plant_line_names = []
+    @new_plant_lines = []
+    @new_plant_varieties = {}
+    @new_plant_accessions = {}
+
     csv.each do |row|
       next unless correct_input?(row)
-      species, plant_variety_name, crop_type, plant_line_name, common_name, previous_line_name, genetic_status, sequence, plant_accession, originating_organisation, year_produced = parse_row(row)
-      if new_plant_variety?(plant_variety_name)
-        @plant_varieties[plant_line_name] = {
-          plant_variety_name: plant_variety_name,
-          crop_type: crop_type
-        }
+
+      pv_attrs, pl_attrs, pa_attrs = parse_row(row)
+      plant_line_name = pl_attrs.fetch(:plant_line_name)
+      plant_variety_name = pv_attrs[:plant_variety_name]
+
+      @new_plant_varieties[plant_line_name] = pv_attrs if new_plant_variety?(plant_variety_name)
+
+      if complete_plant_accession?(pa_attrs) && !existing_plant_accession?(pa_attrs)
+        @new_plant_accessions[plant_line_name] = pa_attrs
       end
-      if [plant_accession, originating_organisation, year_produced].all?(&:present?)
-        @plant_accessions[plant_line_name] = {
-          plant_accession: plant_accession,
-          originating_organisation: originating_organisation,
-          year_produced: year_produced
-        }
+
+      @plant_line_names << plant_line_name
+
+      unless existing_plant_line(plant_line_name).present?
+        @new_plant_lines << pl_attrs.merge(plant_variety_name: plant_variety_name)
       end
-      @plant_lines << {
-        plant_line_name: plant_line_name,
-        plant_variety_name: plant_variety_name,
-        taxonomy_term: species,
-        common_name: common_name,
-        previous_line_name: previous_line_name,
-        genetic_status: genetic_status,
-        sequence_identifier: sequence
-      }
     end
-    @upload.log "Parsed #{@plant_lines.size} correct plant line(s)."
-    @upload.log "Out of them, #{@plant_accessions.size} have plant accession(s) defined."
-    @upload.log "Detected #{@plant_varieties.size} plant line(s) of new (i.e. not existing in BIP) plant variety(ies)."
+
+    @upload.log "Parsed #{@plant_line_names.size} correct plant line(s)."
+    @upload.log "Out of them, #{@new_plant_lines.size} are new."
+    @upload.log "Out of them, #{@new_plant_accessions.size} have plant accession(s) defined."
+    @upload.log "Detected #{@new_plant_varieties.size} plant line(s) of new (i.e. not existing in BIP) plant variety(ies)."
   end
 
   def csv
@@ -91,27 +88,31 @@ class Submission::PlantLineParser
   end
 
   def correct_input?(row)
-    species, _plant_variety_name, _crop_type, plant_line_name, _common_name, _previous_line_name, _genetic_status, _sequence, plant_accession, originating_organisation, year_produced = parse_row(row)
+    pv_attrs, pl_attrs, pa_attrs = parse_row(row)
+
+    plant_line_name = pl_attrs[:plant_line_name]
+    taxonomy_term_name = pl_attrs[:taxonomy_term]
+
     return false if plant_line_name.blank?
-    if plant_line_names.include? plant_line_name
-      @upload.log "Ignored row for #{plant_line_name} since a plant line with that name is already defined in the uploaded file."
-    elsif current_plant_lines.include? plant_line_name
-      @upload.log "Ignored row for #{plant_line_name} since a plant line with that name is already defined. Please clear the 'Plant line list' field before re-uploading a CSV file."
-    elsif reused_plant_line?(plant_line_name)
-      @upload.log "Ignored row for #{plant_line_name} since a plant line with that name is already present in BIP."\
-                  "Please use the 'Plant line list' field to add this existing plant line to the submitted population."
-    elsif species.blank?
+
+    if taxonomy_term_name.blank?
       @upload.log "Ignored row for #{plant_line_name} since Species name is missing."
-    elsif existing_plant_accession?(plant_accession, originating_organisation, year_produced)
-      @upload.log "Ignored row for #{plant_line_name} since it refers to a plant accession which currently exists in BIP."\
-                  "If your intention was to refer to an existing accession, please leave the Plant accession, Originating organisation and Year produced values blank for this plant line."
-    elsif incomplete_plant_accession?(plant_accession, originating_organisation, year_produced)
-      @upload.log "Ignored row for #{plant_line_name} since incomplete plant accession was given."\
+    elsif TaxonomyTerm.find_by_name(taxonomy_term_name).blank?
+      @upload.log "Ignored row for #{plant_line_name} since taxonomy unit called #{taxonomy_term_name} was not found in BIP."
+    elsif reused_plant_line?(plant_line_name)
+      @upload.log "Ignored row for #{plant_line_name} since a plant line with that name is already defined in the uploaded file."
+    elsif current_new_plant_lines.include?(plant_line_name)
+      @upload.log "Ignored row for #{plant_line_name} since a plant line with that name is already defined. Please clear the 'Plant line list' field before re-uploading a CSV file."
+    elsif existing_plant_line?(plant_line_name) && !existing_plant_line_match?(pl_attrs, pv_attrs)
+      @upload.log "Ignored row for #{plant_line_name} since a plant line with that name is already present in BIP "\
+                  "but uploaded data does not match existing record."
+    elsif existing_plant_accession?(pa_attrs) && !existing_plant_accession_match?(pa_attrs, plant_line_name)
+      @upload.log "Ignored row for #{plant_line_name} since it refers to a plant accession which currently exists in BIP and belongs to other plant line."
+    elsif incomplete_plant_accession?(pa_attrs)
+      @upload.log "Ignored row for #{plant_line_name} since incomplete plant accession was given. "\
                   "Either all or none of the Plant accession, Originating organisation and Year produced values must be provided."
-    elsif reused_plant_accession?(plant_accession, originating_organisation, year_produced)
+    elsif reused_plant_accession?(pa_attrs)
       @upload.log "Ignored row for #{plant_line_name} since the defined plant accession was already used for another plant line in this file."
-    elsif TaxonomyTerm.find_by_name(species).blank?
-      @upload.log "Ignored row for #{plant_line_name} since taxonomy unit called #{species} was not found in BIP."
     else
       return true
     end
@@ -119,43 +120,79 @@ class Submission::PlantLineParser
   end
 
   def parse_row(row)
-    row.map { |d| d.nil? ? '' : d.strip }
-  end
+    row = row.map { |d| d ? d.strip : d }
 
-  def plant_line_names
-    @plant_lines.map { |plant_line| plant_line[:plant_line_name] }
+    [
+      { plant_variety_name: row[1], crop_type: row[2] }.compact,
+      { plant_line_name: row[3], common_name: row[4], previous_line_name: row[5],
+        genetic_status: row[6], sequence_identifier: row[7], taxonomy_term: row[0] }.compact,
+      { plant_accession: row[8], originating_organisation: row[9], year_produced: row[10] }.compact
+    ]
   end
 
   def new_plant_variety?(plant_variety_name)
-    plant_variety_name.present? &&
-      PlantVariety.find_by_plant_variety_name(plant_variety_name).blank?
+    plant_variety_name.present? && PlantVariety.where(plant_variety_name: plant_variety_name).blank?
   end
 
-  def existing_plant_accession?(plant_accession, originating_organisation, year_produced)
-    PlantAccession.where(
-      plant_accession: plant_accession,
-      originating_organisation: originating_organisation,
-      year_produced: year_produced).present?
+  def existing_plant_accession?(pa_attrs)
+    existing_plant_accession(pa_attrs).present?
   end
 
-  def incomplete_plant_accession?(*pa_data)
-    pa_data.any?(&:present?) && pa_data.any?(&:blank?)
+  def existing_plant_accession_match?(pa_attrs, plant_line_name)
+    existing_accession = existing_plant_accession(pa_attrs)
+    existing_accession.plant_line.plant_line_name == plant_line_name
   end
 
-  def reused_plant_line?(plant_line_name)
-    PlantLine.find_by(plant_line_name: plant_line_name)
+  def existing_plant_accession(pa_attrs)
+    pa_attrs.present? && PlantAccession.find_by(pa_attrs)
   end
 
-  def reused_plant_accession?(plant_accession, originating_organisation, year_produced)
-    @plant_accessions.any? do |_, pa|
+  def complete_plant_accession?(plant_accession: nil, originating_organisation: nil, year_produced: nil)
+    plant_accession.present? && originating_organisation.present? && year_produced.present?
+  end
+
+  def incomplete_plant_accession?(pa_attrs)
+    pa_attrs.present? && !complete_plant_accession?(pa_attrs)
+  end
+
+  def reused_plant_accession?(plant_accession: nil, originating_organisation: nil, year_produced: nil)
+    @new_plant_accessions.any? do |_, pa|
       pa[:plant_accession] == plant_accession &&
         pa[:originating_organisation] == originating_organisation &&
         pa[:year_produced] == year_produced
     end
   end
 
+  def reused_plant_line?(plant_line_name)
+    @plant_line_names.include?(plant_line_name)
+  end
+
+  def existing_plant_line?(plant_line_name)
+    existing_plant_line(plant_line_name).present?
+  end
+
+  def existing_plant_line_match?(pl_attrs, pv_attrs)
+    existing_line = existing_plant_line(pl_attrs.fetch(:plant_line_name))
+
+    return false if pv_attrs.any? { |attr, val| existing_line.plant_variety.try(attr) != val }
+    return false if pl_attrs.except(:taxonomy_term).any? { |attr, val| existing_line.try(attr) != val }
+    return false if pl_attrs.fetch(:taxonomy_term) != existing_line.taxonomy_term.try(:name)
+
+    true
+  end
+
+  def existing_plant_line(plant_line_name)
+    PlantLine.
+      visible(@upload.submission.user_id).
+      find_by(plant_line_name: plant_line_name)
+  end
+
   def current_plant_lines
     @current_plant_lines ||= @upload.submission.content.plant_line_list || []
+  end
+
+  def current_new_plant_lines
+    @current_new_plant_lines ||= (@upload.submission.content.new_plant_lines || []).map { |pl| pl["plant_line_name"] }
   end
 
   def header_columns

--- a/app/services/submission/plant_population_finalizer.rb
+++ b/app/services/submission/plant_population_finalizer.rb
@@ -25,12 +25,13 @@ class Submission::PlantPopulationFinalizer
   def create_new_plant_lines
     new_plant_varieties = submission.content.new_plant_varieties || {}
     new_plant_accessions = submission.content.new_plant_accessions || {}
+
     @new_plant_lines = (submission.content.new_plant_lines || []).map do |attrs|
       attrs = attrs.with_indifferent_access
       taxonomy_term = TaxonomyTerm.find_by!(name: attrs.delete(:taxonomy_term))
-      attrs = attrs.merge(
-        taxonomy_term_id: taxonomy_term.id
-      ).merge(common_data)
+      attrs = attrs.
+        merge(taxonomy_term_id: taxonomy_term.id).
+        merge(common_data)
 
       if (plant_variety = new_plant_varieties[attrs[:plant_line_name]]).present? || attrs[:plant_variety_name].present?
         plant_variety_name = plant_variety.try(:[], 'plant_variety_name') || attrs[:plant_variety_name]

--- a/app/views/submissions/steps/population/_step03.html.haml
+++ b/app/views/submissions/steps/population/_step03.html.haml
@@ -85,6 +85,6 @@
       %button.btn.btn-primary.add-new-plant-line-for-list{type: 'button'} Confirm
 
 - @content.new_plant_lines.each do |plant_line|
-  %div{ id: "new-plant-line-#{plant_line.plant_line_name.split.join('-').downcase}" }
+  %div{ id: "new-plant-line-#{plant_line.plant_line_name.split.join('-').downcase}", class: "new-plant-line-attrs" }
     - @content.class.new_plant_line_properties.each do |attr|
       = hidden_field_tag "submission[content][new_plant_lines][][#{attr}]", plant_line.send(attr)

--- a/app/views/submissions/steps/population/_step03_before.html.haml
+++ b/app/views/submissions/steps/population/_step03_before.html.haml
@@ -62,6 +62,10 @@
     columns</i>. Also, your organisation should ensure the unique naming of accession - so you never
     duplicate the <b>Plant accession</b> value in the context of the same <b>Originating organisation</b>.
 
+  %p
+    When including plant lines already defined in BIP it is best to skip all optional information. Otherwise, any
+    conflicts with existing data will prevent plant lines from being included in submitted population.
+
 .errors.hidden
 
 = form_tag submission_uploads_path(submission), multipart: true, method: :post do

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -15,22 +15,21 @@ en:
         submission/upload:
           attributes:
             file:
-              no_header: 'No correct header provided. At least four columns are expected.'
-              no_header_plant_lines: 'No correct header provided.'
-              no_plant_accession_header: 'No correct header provided. Please provide the "Plant accession" column.'
-              no_originating_organisation_header: 'No correct header provided. Please provide the "Originating organisation" column.'
-              no_year_produced_header: 'No correct header provided. Please provide the "Year produced" column.'
-              no_plant_line_header: 'No correct header provided. Please provide the "Plant line" column.'
-              no_common_name_header: 'No correct header provided. Please provide the "Common name" column.'
-              no_previous_line_name_header: 'No correct header provided. Please provide the "Previous line name" column.'
-              no_genetic_status_header: 'No correct header provided. Please provide the "Genetic status" column.'
-              no_sequence_header: 'No correct header provided. Please provide the "Sequence" column.'
-              no_line_or_variety_header: 'No correct header provided. Please provide either the "Plant line" or the "Plant variety" column.'
-              no_plant_variety_header: 'No correct header provided. Please provide the "Plant variety" column.'
-              no_species_header: 'No correct header provided. Please provide the "Species" column.'
-              no_crop_type_header: 'No correct header provided. Please provide the "Crop type" column.'
-              non_unique_mapping: 'Detected non unique column headers mapping
-                to traits. Please check the column names.'
+              no_header: 'has no correct header provided. At least four columns are expected.'
+              no_header_plant_lines: 'has no correct header provided.'
+              no_plant_accession_header: 'has no correct header provided. Please provide the "Plant accession" column.'
+              no_originating_organisation_header: 'has no correct header provided. Please provide the "Originating organisation" column.'
+              no_year_produced_header: 'has no correct header provided. Please provide the "Year produced" column.'
+              no_plant_line_header: 'has no correct header provided. Please provide the "Plant line" column.'
+              no_common_name_header: 'has no correct header provided. Please provide the "Common name" column.'
+              no_previous_line_name_header: 'has no correct header provided. Please provide the "Previous line name" column.'
+              no_genetic_status_header: 'has no correct header provided. Please provide the "Genetic status" column.'
+              no_sequence_header: 'has no correct header provided. Please provide the "Sequence" column.'
+              no_line_or_variety_header: 'has no correct header provided. Please provide either the "Plant line" or the "Plant variety" column.'
+              no_plant_variety_header: 'has no correct header provided. Please provide the "Plant variety" column.'
+              no_species_header: 'has no correct header provided. Please provide the "Species" column.'
+              no_crop_type_header: 'has no correct header provided. Please provide the "Crop type" column.'
+              non_unique_mapping: 'Detected non unique column headers mapping to traits. Please check the column names.'
         trait:
           attributes:
             name:

--- a/spec/fixtures/files/plant_lines_upload.txt
+++ b/spec/fixtures/files/plant_lines_upload.txt
@@ -4,3 +4,5 @@ Brassica napus,Valesca,Winter oilseed rape,pl_wrong_repeated_pa,,,,,New accessio
 Brassica napus,Valesca,Winter oilseed rape,pl_ok_nopa,Correct plant line,pl_ok_old,inbred,SRR3134398
 Brassica napus,Valesca,Winter oilseed rape,pl_wrong_partial_pa,,,,,,My org,2014
 Brassica napus,Valesca,Winter oilseed rape,pl_wrong_existing_pa,,,,,whri2004_C1,WHRI,2004
+,,,existing_pl
+,,,existing_pl_newpa,,,,,New accession Y,EI,2018

--- a/spec/services/submission/plant_line_parser_spec.rb
+++ b/spec/services/submission/plant_line_parser_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Submission::PlantLineParser do
       input_is ''
       subject.send(:parse_header)
       expect(upload.errors[:file]).
-        to eq ['No correct header provided.']
+        to eq ['has no correct header provided.']
     end
 
     header = [
@@ -31,7 +31,7 @@ RSpec.describe Submission::PlantLineParser do
         input_is header.reject{ |c| c == column_name }.join(',')
         subject.send(:parse_header)
         expect(upload.errors[:file]).
-          to eq ["No correct header provided. Please provide the \"#{column_name}\" column."]
+          to eq ["has no correct header provided. Please provide the \"#{column_name}\" column."]
       end
     end
 

--- a/spec/services/submission/trait_score_parser_spec.rb
+++ b/spec/services/submission/trait_score_parser_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Submission::TraitScoreParser do
         input_is 'single column name'
         subject.send(:parse_header)
         expect(upload.errors[:file]).
-          to eq ['No correct header provided. At least four columns are expected.']
+          to eq ['has no correct header provided. At least four columns are expected.']
       end
 
       it 'does nothing with a four-column header' do
@@ -30,14 +30,14 @@ RSpec.describe Submission::TraitScoreParser do
         input_is 'id,pa,oo,yp,pl'
         subject.send(:parse_header)
         expect(upload.errors[:file]).
-          to eq ['No correct header provided. Please provide the "Plant accession" column.']
+          to eq ['has no correct header provided. Please provide the "Plant accession" column.']
       end
 
       it 'complains if there is neither Plant line nor Plant variety column' do
         input_is 'id,Plant accession,oo,yp,pl'
         subject.send(:parse_header)
         expect(upload.errors[:file]).
-          to eq ['No correct header provided. Please provide either the "Plant line" or the "Plant variety" column.']
+          to eq ['has no correct header provided. Please provide either the "Plant line" or the "Plant variety" column.']
       end
     end
 


### PR DESCRIPTION
Partial fix for #756 

Allows to include existing PLs in uploaded file provided submitted data matches existing records. Does not yet allow to update existing data as suggested by Wiktor in a comment to #756.
